### PR TITLE
Replace granular DB-table debug UI with purpose-built admin actions

### DIFF
--- a/lib/cubits/settings/settings_cubit.dart
+++ b/lib/cubits/settings/settings_cubit.dart
@@ -3,10 +3,14 @@ import 'package:questvale/cubits/home/player_cubit.dart';
 import 'package:questvale/cubits/settings/settings_state.dart';
 import 'package:questvale/cubits/theme/theme_cubit.dart';
 import 'package:questvale/data/models/character.dart';
+import 'package:questvale/data/models/character_stats.dart';
 import 'package:questvale/data/models/encounter.dart';
 import 'package:questvale/data/providers/game_data.dart';
 import 'package:questvale/data/repositories/character_repository.dart';
+import 'package:questvale/data/repositories/encounter_repository.dart';
 import 'package:questvale/data/repositories/equipment_repository.dart';
+import 'package:questvale/data/repositories/quest_repository.dart';
+import 'package:questvale/data/repositories/todo_repository.dart';
 import 'package:questvale/services/equipment_service.dart';
 import 'package:sqflite/sqflite.dart';
 
@@ -17,6 +21,9 @@ class SettingsCubit extends Cubit<SettingsState> {
   final ThemeCubit themeCubit;
   late EquipmentRepository equipmentRepository;
   late CharacterRepository characterRepository;
+  late QuestRepository questRepository;
+  late EncounterRepository encounterRepository;
+  late TodoRepository todoRepository;
 
   SettingsCubit(
       {required this.db,
@@ -24,83 +31,21 @@ class SettingsCubit extends Cubit<SettingsState> {
       required this.playerCubit,
       required this.themeCubit,
       required Character character})
-      : super(SettingsState(
-            character: character,
-            questsNum: 0,
-            encountersNum: 0,
-            enemiesNum: 0,
-            tableInfos: [])) {
-    loadSettings();
+      : super(SettingsState(character: character)) {
     equipmentRepository = EquipmentRepository(db: db);
     characterRepository = CharacterRepository(db: db);
+    questRepository = QuestRepository(db: db);
+    encounterRepository = EncounterRepository(db: db);
+    todoRepository = TodoRepository(db: db);
   }
 
   void setTheme(String themeId) => themeCubit.setTheme(themeId);
 
-  Future<void> loadSettings() async {
-    final tableInfos = [
-      TableInfo(
-          tableType: TableType.quests,
-          numRows: await getTableLength(TableType.quests)),
-      TableInfo(
-          tableType: TableType.encounters,
-          numRows: await getTableLength(TableType.encounters)),
-      TableInfo(
-          tableType: TableType.enemies,
-          numRows: await getTableLength(TableType.enemies)),
-      TableInfo(
-          tableType: TableType.encounterRewards,
-          numRows: await getTableLength(TableType.encounterRewards)),
-      TableInfo(
-          tableType: TableType.characterTags,
-          numRows: await getTableLength(TableType.characterTags)),
-      TableInfo(
-          tableType: TableType.todos,
-          numRows: await getTableLength(TableType.todos)),
-      TableInfo(
-          tableType: TableType.todoTags,
-          numRows: await getTableLength(TableType.todoTags)),
-      TableInfo(
-          tableType: TableType.todoReminders,
-          numRows: await getTableLength(TableType.todoReminders)),
-      TableInfo(
-          tableType: TableType.characters,
-          numRows: await getTableLength(TableType.characters),
-          isDeletable: false),
-      TableInfo(
-          tableType: TableType.equipments,
-          numRows: await getTableLength(TableType.equipments)),
-      TableInfo(
-          tableType: TableType.statModifiers,
-          numRows: await getTableLength(TableType.statModifiers)),
-      TableInfo(
-          tableType: TableType.equipmentEncounterRewards,
-          numRows: await getTableLength(TableType.equipmentEncounterRewards)),
-    ];
-    if (!isClosed) {
-      emit(state.copyWith(tableInfos: tableInfos));
-    }
-  }
-
-  Future<int> getTableLength(TableType tableType) async {
-    final tableLength = await db.query(tableType.tableName);
-    return tableLength.length;
-  }
-
-  Future<void> deleteTableContents(TableInfo tableInfo) async {
-    if (tableInfo.isDeletable) {
-      await db.delete(tableInfo.tableType.tableName);
-    }
-    loadSettings();
-  }
-
-  Future<void> logTableContents(TableType tableType) async {
-    final tableContents = await db.query(tableType.tableName);
-    for (var content in tableContents) {
-      print(content);
-    }
-  }
-
+  // Every admin action below finishes with playerCubit.loadCharacter() —
+  // PlayerCubit holds the canonical Character used elsewhere (world_tab,
+  // todo_tab's AP display, etc.) and won't pick up any of these mutations
+  // until reloaded, regardless of whether the action touched the Character
+  // row itself.
   Future<void> generateLoot() async {
     final equipmentService = EquipmentService(db: db);
     final questZones = gameData.questZones;
@@ -109,6 +54,7 @@ class SettingsCubit extends Cubit<SettingsState> {
           state.character, questZones[0], EncounterType.genericCombat);
       await equipmentRepository.insertEquipment(equipment);
     }
+    await playerCubit.loadCharacter();
   }
 
   Future<void> resetAp() async {
@@ -116,8 +62,93 @@ class SettingsCubit extends Cubit<SettingsState> {
       state.character.copyWith(actionPoints: 0, dailyApEarned: 0),
     );
     emit(state.copyWith(character: updated));
-    // PlayerCubit holds the canonical Character used elsewhere (world_tab,
-    // todo_tab's AP display) — it won't pick up this change until reloaded.
     await playerCubit.loadCharacter();
+  }
+
+  Future<void> deleteAllTags() async {
+    await characterRepository.deleteAllTags(state.character.id);
+    await playerCubit.loadCharacter();
+  }
+
+  Future<void> deleteAllTodos() async {
+    await todoRepository.deleteAllTodosForCharacter(state.character.id);
+    await playerCubit.loadCharacter();
+  }
+
+  Future<void> deleteAllEquipment() async {
+    final updated = await characterRepository
+        .updateCharacter(_unequipped(state.character));
+    await equipmentRepository.deleteAllEquipmentForCharacter(updated.id);
+    emit(state.copyWith(character: updated));
+    await playerCubit.loadCharacter();
+  }
+
+  Future<void> cancelQuest() async {
+    final quest = await questRepository.getQuest(state.character.id);
+    if (quest == null) return;
+    final encounter =
+        await encounterRepository.getEncounterByQuestId(quest.id);
+    if (encounter != null) {
+      await encounterRepository.enemyRepository
+          .deleteEnemiesByEncounterId(encounter.id);
+      await encounterRepository.deleteEncounter(encounter);
+    }
+    await encounterRepository.deleteEncounterRewardsByQuestId(quest.id);
+    await questRepository.deleteQuest(quest);
+    await playerCubit.loadCharacter();
+  }
+
+  Future<void> resetCharacter() async {
+    final c = state.character;
+    final reset = Character(
+      id: c.id,
+      name: c.name,
+      characterClass: c.characterClass,
+      level: c.level,
+      gold: 0,
+      currentExp: 0,
+      currentHealth: (c.level * 10) + c.characterClass.baseMaxHealth,
+      currentMana: (c.level * 10) + 10,
+      actionPoints: 0,
+      // equipped* and activeSkillSlot* omitted -> null (unequipped, no
+      // active skills). skills defaults to const [].
+      dailyApEarned: 0,
+      themeId: c.themeId,
+    );
+    final updated = await characterRepository.updateCharacter(reset);
+    await equipmentRepository.deleteAllEquipmentForCharacter(updated.id);
+    await characterRepository.deleteAllSkillsForCharacter(updated.id);
+    await characterRepository
+        .updateCharacterStats(CharacterStats(characterId: updated.id));
+    emit(state.copyWith(character: updated));
+    await playerCubit.loadCharacter();
+  }
+
+  // Character.copyWith can't null a field (its `?? this.field` pattern
+  // treats an explicit null as "unchanged"), so unequipping requires
+  // constructing a new Character directly, omitting every equipped* param
+  // — same workaround used elsewhere in this codebase (e.g.
+  // AddTodoCubit/EditTodoCubit's dueDateCleared()).
+  Character _unequipped(Character c) {
+    return Character(
+      id: c.id,
+      name: c.name,
+      characterClass: c.characterClass,
+      level: c.level,
+      gold: c.gold,
+      currentExp: c.currentExp,
+      currentHealth: c.currentHealth,
+      currentMana: c.currentMana,
+      actionPoints: c.actionPoints,
+      skills: c.skills,
+      activeSkillSlot1: c.activeSkillSlot1,
+      activeSkillSlot2: c.activeSkillSlot2,
+      activeSkillSlot3: c.activeSkillSlot3,
+      activeSkillSlot4: c.activeSkillSlot4,
+      activeSkillSlot5: c.activeSkillSlot5,
+      dailyApEarned: c.dailyApEarned,
+      dailyApEarnedDate: c.dailyApEarnedDate,
+      themeId: c.themeId,
+    );
   }
 }

--- a/lib/cubits/settings/settings_page.dart
+++ b/lib/cubits/settings/settings_page.dart
@@ -10,6 +10,7 @@ import 'package:questvale/data/providers/game_data.dart';
 import 'package:questvale/helpers/constants.dart';
 import 'package:questvale/widgets/qv_app_bar.dart';
 import 'package:questvale/widgets/qv_button.dart';
+import 'package:questvale/widgets/qv_confirmation_modal.dart';
 import 'package:questvale/widgets/qv_fading_scrollable.dart';
 import 'package:sqflite/sqflite.dart';
 
@@ -46,19 +47,6 @@ class SettingsPage extends StatelessWidget {
                           child: Column(
                             spacing: 10,
                             children: [
-                              InfoSlice(
-                                title: 'Quests',
-                                count: settingsState.questsNum,
-                                onTap: settingsState.questsNum > 0
-                                    ? () => context
-                                        .read<SettingsCubit>()
-                                        .deleteTableContents(settingsState
-                                            .tableInfos
-                                            .firstWhere((tableInfo) =>
-                                                tableInfo.tableType ==
-                                                TableType.quests))
-                                    : () => {},
-                              ),
                               Row(
                                 children: [
                                   Expanded(
@@ -116,18 +104,91 @@ class SettingsPage extends StatelessWidget {
                               ),
                               Align(
                                 alignment: Alignment.centerLeft,
-                                child: Text('DB Tables',
+                                child: Text('Admin Actions',
                                     style: TextStyle(
                                         fontSize: 20,
                                         fontWeight: FontWeight.bold,
                                         color: colorScheme.onSurface)),
                               ),
-                              Column(
-                                children: [
-                                  for (var tableInfo
-                                      in settingsState.tableInfos)
-                                    TableInfoSlice(tableInfo: tableInfo),
-                                ],
+                              _AdminActionRow(
+                                label: 'Delete all tasks/todos/habits',
+                                buttonLabel: 'Delete',
+                                onTap: () => QvConfirmationModal.showModal(
+                                  context,
+                                  title: 'Delete all todos?',
+                                  description:
+                                      'Deletes every task and habit, along '
+                                      'with their reminders and tag '
+                                      'assignments. Your tags themselves are '
+                                      'kept. This can\'t be undone.',
+                                  confirmLabel: 'Delete Todos',
+                                  onConfirm: () => context
+                                      .read<SettingsCubit>()
+                                      .deleteAllTodos(),
+                                ),
+                              ),
+                              _AdminActionRow(
+                                label: 'Delete all tags',
+                                buttonLabel: 'Delete',
+                                onTap: () => QvConfirmationModal.showModal(
+                                  context,
+                                  title: 'Delete all tags?',
+                                  description:
+                                      'Removes every tag you\'ve created and '
+                                      'untags all todos. This can\'t be undone.',
+                                  confirmLabel: 'Delete Tags',
+                                  onConfirm: () => context
+                                      .read<SettingsCubit>()
+                                      .deleteAllTags(),
+                                ),
+                              ),
+                              _AdminActionRow(
+                                label: 'Delete/cleanup all equipment',
+                                buttonLabel: 'Delete',
+                                onTap: () => QvConfirmationModal.showModal(
+                                  context,
+                                  title: 'Delete all equipment?',
+                                  description:
+                                      'Unequips and deletes every piece of '
+                                      'gear you own, worn or not. This '
+                                      'can\'t be undone.',
+                                  confirmLabel: 'Delete Equipment',
+                                  onConfirm: () => context
+                                      .read<SettingsCubit>()
+                                      .deleteAllEquipment(),
+                                ),
+                              ),
+                              _AdminActionRow(
+                                label: 'Cancel/delete quest',
+                                buttonLabel: 'Cancel',
+                                onTap: () => QvConfirmationModal.showModal(
+                                  context,
+                                  title: 'Cancel the current quest?',
+                                  description:
+                                      'Ends your active quest and deletes any '
+                                      'progress in it. This can\'t be undone.',
+                                  confirmLabel: 'Cancel Quest',
+                                  onConfirm: () => context
+                                      .read<SettingsCubit>()
+                                      .cancelQuest(),
+                                ),
+                              ),
+                              _AdminActionRow(
+                                label: 'Reset character to initial config',
+                                buttonLabel: 'Reset',
+                                onTap: () => QvConfirmationModal.showModal(
+                                  context,
+                                  title: 'Reset character?',
+                                  description:
+                                      'Resets level progress, gold, exp, AP, '
+                                      'equipment, and skills back to a fresh '
+                                      'start. Your todos and name are kept. '
+                                      'This can\'t be undone.',
+                                  confirmLabel: 'Reset Character',
+                                  onConfirm: () => context
+                                      .read<SettingsCubit>()
+                                      .resetCharacter(),
+                                ),
                               ),
                             ],
                           ),
@@ -145,99 +206,35 @@ class SettingsPage extends StatelessWidget {
   }
 }
 
-class TableInfoSlice extends StatelessWidget {
-  final TableInfo tableInfo;
-  const TableInfoSlice({super.key, required this.tableInfo});
+class _AdminActionRow extends StatelessWidget {
+  final String label;
+  final String buttonLabel;
+  final VoidCallback onTap;
 
-  @override
-  Widget build(BuildContext context) {
-    ColorScheme colorScheme = Theme.of(context).colorScheme;
-    return SizedBox(
-      height: 50,
-      child: Row(
-        spacing: 10,
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Expanded(
-              child: Text(tableInfo.tableType.name,
-                  style:
-                      TextStyle(fontSize: 16, color: colorScheme.onSurface))),
-          SizedBox(
-              width: 40,
-              child: Text(tableInfo.numRows.toString(),
-                  style:
-                      TextStyle(fontSize: 20, color: colorScheme.onSurface))),
-          QvButton(
-            height: 40,
-            width: tableInfo.isDeletable ? 60 : 130,
-            buttonColor: ButtonColor.silver,
-            onTap: () {
-              context
-                  .read<SettingsCubit>()
-                  .logTableContents(tableInfo.tableType);
-            },
-            child: Center(
-              child: Text('Log',
-                  style: TextStyle(color: colorScheme.onPrimary, fontSize: 18)),
-            ),
-          ),
-          tableInfo.isDeletable
-              ? QvButton(
-                  height: 40,
-                  width: 80,
-                  buttonColor: ButtonColor.silver,
-                  onTap: () {
-                    context
-                        .read<SettingsCubit>()
-                        .deleteTableContents(tableInfo);
-                  },
-                  child: Center(
-                    child: Text('Delete',
-                        style: TextStyle(
-                            color: colorScheme.onPrimary, fontSize: 18)),
-                  ),
-                )
-              : SizedBox.shrink(),
-        ],
-      ),
-    );
-  }
-}
-
-class InfoSlice extends StatelessWidget {
-  final String title;
-  final int count;
-  final Function() onTap;
-  const InfoSlice(
-      {super.key,
-      required this.title,
-      required this.count,
-      required this.onTap});
+  const _AdminActionRow({
+    required this.label,
+    required this.buttonLabel,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
     ColorScheme colorScheme = Theme.of(context).colorScheme;
     return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        SizedBox(
-            width: 120,
-            child: Text(title,
-                style: TextStyle(fontSize: 20, color: colorScheme.onSurface))),
-        SizedBox(
-            width: 80,
-            child: Text(count.toString(),
-                style: TextStyle(fontSize: 20, color: colorScheme.onSurface))),
         Expanded(
-          child: QvButton(
-            buttonColor: ButtonColor.silver,
-            onTap: onTap,
-            height: 50,
-            width: double.infinity,
-            child: Center(
-              child: Text(count > 0 ? 'Delete all $title' : 'None to delete',
-                  style: TextStyle(color: colorScheme.onPrimary, fontSize: 20)),
-            ),
+            child: Text(label,
+                style:
+                    TextStyle(fontSize: 20, color: colorScheme.onSurface))),
+        QvButton(
+          width: 180,
+          height: 50,
+          buttonColor: ButtonColor.silver,
+          onTap: onTap,
+          child: Center(
+            child: Text(buttonLabel,
+                style:
+                    TextStyle(fontSize: 20, color: colorScheme.onPrimary)),
           ),
         ),
       ],

--- a/lib/cubits/settings/settings_state.dart
+++ b/lib/cubits/settings/settings_state.dart
@@ -1,104 +1,15 @@
 import 'package:equatable/equatable.dart';
 import 'package:questvale/data/models/character.dart';
 
-enum TableType {
-  characters,
-  characterTags,
-  todos,
-  todoTags,
-  todoReminders,
-  quests,
-  questZones,
-  encounters,
-  encounterRewards,
-  enemies,
-  enemyData,
-  enemyAttackData,
-  enemyDropData,
-  equipments,
-  statModifiers,
-  equipmentEncounterRewards;
-
-  String get tableName {
-    switch (this) {
-      case TableType.characters:
-        return 'Characters';
-      case TableType.characterTags:
-        return 'CharacterTags';
-      case TableType.todos:
-        return 'Todos';
-      case TableType.todoTags:
-        return 'TodoTags';
-      case TableType.todoReminders:
-        return 'TodoReminders';
-      case TableType.quests:
-        return 'Quests';
-      case TableType.questZones:
-        return 'QuestZones';
-      case TableType.encounters:
-        return 'Encounters';
-      case TableType.encounterRewards:
-        return 'EncounterRewards';
-      case TableType.enemies:
-        return 'Enemies';
-      case TableType.enemyData:
-        return 'EnemyData';
-      case TableType.enemyAttackData:
-        return 'EnemyAttackData';
-      case TableType.enemyDropData:
-        return 'EnemyDropData';
-      case TableType.equipments:
-        return 'Equipments';
-      case TableType.statModifiers:
-        return 'StatModifiers';
-      case TableType.equipmentEncounterRewards:
-        return 'EquipmentEncounterRewards';
-    }
-  }
-}
-
-class TableInfo {
-  final TableType tableType;
-  final int numRows;
-  final bool isDeletable;
-  const TableInfo(
-      {required this.tableType,
-      required this.numRows,
-      this.isDeletable = true});
-}
-
 class SettingsState extends Equatable {
   final Character character;
-  final int questsNum;
-  final int encountersNum;
-  final int enemiesNum;
-  final List<TableInfo> tableInfos;
 
-  const SettingsState({
-    required this.character,
-    required this.questsNum,
-    required this.encountersNum,
-    required this.enemiesNum,
-    required this.tableInfos,
-  });
+  const SettingsState({required this.character});
 
-  SettingsState copyWith({
-    Character? character,
-    int? questsNum,
-    int? encountersNum,
-    int? enemiesNum,
-    List<TableInfo>? tableInfos,
-  }) {
-    return SettingsState(
-      character: character ?? this.character,
-      questsNum: questsNum ?? this.questsNum,
-      encountersNum: encountersNum ?? this.encountersNum,
-      enemiesNum: enemiesNum ?? this.enemiesNum,
-      tableInfos: tableInfos ?? this.tableInfos,
-    );
+  SettingsState copyWith({Character? character}) {
+    return SettingsState(character: character ?? this.character);
   }
 
   @override
-  List<Object?> get props =>
-      [character, questsNum, encountersNum, enemiesNum, tableInfos];
+  List<Object?> get props => [character];
 }

--- a/lib/data/repositories/character_repository.dart
+++ b/lib/data/repositories/character_repository.dart
@@ -2,6 +2,7 @@ import 'package:questvale/data/models/character.dart';
 import 'package:questvale/data/models/character_skill.dart';
 import 'package:questvale/data/models/character_stats.dart';
 import 'package:questvale/data/models/character_tag.dart';
+import 'package:questvale/data/models/todo_tag.dart';
 import 'package:questvale/data/repositories/equipment_repository.dart';
 import 'package:questvale/helpers/constants.dart';
 import 'package:questvale/helpers/shared_enums.dart';
@@ -98,6 +99,25 @@ class CharacterRepository {
       CharacterTag.characterTagTableName,
       where: '${CharacterTag.idColumnName} = ?',
       whereArgs: [tag.id],
+    );
+  }
+
+  // Deletes every tag the character owns, and any TodoTags rows
+  // referencing them so no todo is left pointing at a deleted tag.
+  Future<void> deleteAllTags(String characterId) async {
+    final tags = await getCharacterTags(characterId);
+    if (tags.isEmpty) return;
+    final tagIds = tags.map((tag) => tag.id).toList();
+    await db.delete(
+      TodoTag.todoTagTableName,
+      where:
+          '${TodoTag.characterTagIdColumnName} IN (${List.filled(tagIds.length, '?').join(',')})',
+      whereArgs: tagIds,
+    );
+    await db.delete(
+      CharacterTag.characterTagTableName,
+      where: '${CharacterTag.characterIdColumnName} = ?',
+      whereArgs: [characterId],
     );
   }
 
@@ -236,6 +256,14 @@ class CharacterRepository {
       whereArgs: [characterId],
     );
     return skillMaps.map((skillMap) => _getSkillFromMap(skillMap)).toList();
+  }
+
+  Future<void> deleteAllSkillsForCharacter(String characterId) async {
+    await db.delete(
+      CharacterSkill.characterSkillTableName,
+      where: '${CharacterSkill.characterIdColumnName} = ?',
+      whereArgs: [characterId],
+    );
   }
 
   Future<CharacterSkill?> getSkillById(String? skillId) async {

--- a/lib/data/repositories/equipment_repository.dart
+++ b/lib/data/repositories/equipment_repository.dart
@@ -77,6 +77,16 @@ class EquipmentRepository {
     await statModifiersRepository.deleteStatModifiersByEquipmentId(equipmentId);
   }
 
+  // DELETE ALL EQUIPMENT FOR CHARACTER
+  // Loops through deleteEquipment per row (rather than a bulk SQL delete)
+  // so each item's StatModifiers cascade-delete still fires.
+  Future<void> deleteAllEquipmentForCharacter(String characterId) async {
+    final equipment = await getEquipmentByCharacterId(characterId);
+    for (final item in equipment) {
+      await deleteEquipment(item.id);
+    }
+  }
+
   // map method for equipment
   Future<Equipment> _getEquipmentFromMap(Map<String, Object?> map) async {
     final statModifiers = await statModifiersRepository

--- a/lib/data/repositories/todo_repository.dart
+++ b/lib/data/repositories/todo_repository.dart
@@ -67,6 +67,26 @@ class TodoRepository {
     );
   }
 
+  // DELETE ALL TODOS FOR CHARACTER
+  // Also cleans up TodoTags/TodoReminders for those todos — deleteTodo
+  // above only removes the Todos row itself, which would otherwise leave
+  // orphaned join/reminder rows behind for every deleted todo.
+  Future<void> deleteAllTodosForCharacter(String characterId) async {
+    final todoMaps = await db.query(Todo.todoTableName,
+        where: '${Todo.characterIdColumnName} = ?', whereArgs: [characterId]);
+    final todoIds = todoMaps.map((map) => map[Todo.idColumnName] as String).toList();
+    if (todoIds.isEmpty) return;
+    final placeholders = List.filled(todoIds.length, '?').join(',');
+    await db.delete(TodoReminder.todoReminderTableName,
+        where: '${TodoReminder.todoIdColumnName} IN ($placeholders)',
+        whereArgs: todoIds);
+    await db.delete(TodoTag.todoTagTableName,
+        where: '${TodoTag.todoIdColumnName} IN ($placeholders)',
+        whereArgs: todoIds);
+    await db.delete(Todo.todoTableName,
+        where: '${Todo.characterIdColumnName} = ?', whereArgs: [characterId]);
+  }
+
   // INSERT todo
   Future<void> createTodo(Todo todo) async {
     await db.insert(

--- a/lib/widgets/qv_confirmation_modal.dart
+++ b/lib/widgets/qv_confirmation_modal.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:questvale/widgets/qv_button.dart';
+import 'package:questvale/widgets/qv_metal_corner_border.dart';
+
+/// Generic destructive-action confirmation dialog, matching
+/// QuestFleeConfirmationModal's look but parameterized for reuse (e.g. the
+/// Settings page's admin actions).
+class QvConfirmationModal extends StatelessWidget {
+  final String title;
+  final String description;
+  final String confirmLabel;
+  final Future<void> Function() onConfirm;
+
+  const QvConfirmationModal({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.confirmLabel,
+    required this.onConfirm,
+  });
+
+  static Future<void> showModal(
+    BuildContext context, {
+    required String title,
+    required String description,
+    required String confirmLabel,
+    required Future<void> Function() onConfirm,
+  }) {
+    return showDialog<void>(
+      context: context,
+      builder: (context) => QvConfirmationModal(
+        title: title,
+        description: description,
+        confirmLabel: confirmLabel,
+        onConfirm: onConfirm,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ColorScheme colorScheme = Theme.of(context).colorScheme;
+    return Center(
+      child: SizedBox(
+        width: 360,
+        height: 280,
+        child: QvMetalCornerBorder(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+          child: Column(
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                      child: SizedBox(
+                    height: 54,
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        title,
+                        style: TextStyle(
+                          fontSize: 26,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                  )),
+                  GestureDetector(
+                    onTap: () => Navigator.pop(context),
+                    child: SizedBox(
+                      width: 20,
+                      height: 40,
+                      child: Align(
+                        alignment: Alignment.topCenter,
+                        child: Text(
+                          'x',
+                          style: TextStyle(
+                            fontSize: 36,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              Container(
+                height: 2,
+                width: MediaQuery.of(context).size.width * 0.7,
+                color: colorScheme.secondary,
+              ),
+              SizedBox(height: 10),
+              Expanded(
+                child: Text(
+                  description,
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: colorScheme.onSurface,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              QvButton(
+                onTap: () async {
+                  Navigator.pop(context);
+                  await onConfirm();
+                },
+                width: 200,
+                height: 50,
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                buttonColor: ButtonColor.primary,
+                child: Center(
+                  child: Text(
+                    confirmLabel,
+                    style:
+                        TextStyle(fontSize: 26, color: colorScheme.secondary),
+                  ),
+                ),
+              ),
+              SizedBox(height: 20),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Settings previously exposed a raw per-table debug tool: every DB table listed with a live row count, a Log button, and (for most) a Delete button that wiped the entire table across all characters with zero confirmation. There was also a separate "Delete all Quests" button that was silently dead (its count was never populated).

Replaces all of that with five purpose-built, confirmed actions: delete all tasks/todos/habits (+ their reminders and tag assignments), delete all tags, delete/cleanup all equipment (unequips + deletes everything, cascading stat modifiers), cancel/delete the active quest, and reset the character to a fresh-start config (level kept, but gold/exp/AP zeroed, HP/MP full, gear and skills cleared, CharacterStats reset — todos and the active quest are left alone). Generate Loot, Reset AP, and Theme stay unchanged.

Each destructive action now goes through a confirmation dialog (QvConfirmationModal, generalized from the existing QuestFleeConfirmationModal pattern) before executing. All seven SettingsCubit actions consistently call playerCubit.loadCharacter() on completion so other tabs (world_tab, todo_tab's AP display) never show stale character data after a Settings mutation.

New repository methods: CharacterRepository.deleteAllTags/ deleteAllSkillsForCharacter, EquipmentRepository.
deleteAllEquipmentForCharacter, TodoRepository.
deleteAllTodosForCharacter (the last one needed writing from scratch since the existing single-row deleteTodo doesn't cascade to TodoTags/TodoReminders). Dead TableType/TableInfo/InfoSlice/ TableInfoSlice code removed.