### PR TITLE
Enemy attack scheduling

### DIFF
--- a/lib/cubits/todo_tab/todos_overview/combat_status_card.dart
+++ b/lib/cubits/todo_tab/todos_overview/combat_status_card.dart
@@ -67,12 +67,32 @@ class _CombatStatusCardState extends State<CombatStatusCard> {
     // styles are represented.
     _placeholderSkillCooldowns[random.nextInt(_skillSlotCount)] = Duration.zero;
 
-    // Purely presentational — recomputes nextTriggerAt - now() on a plain
-    // UI timer, no business logic here. Hour/day-scale timers don't need
-    // per-second precision, per the scheduling engine's UI countdown notes.
+    // Recomputes nextTriggerAt - now() every second, so the countdown
+    // visibly ticks down rather than jumping in chunks — purely
+    // presentational when nothing has expired yet. But once an enemy's
+    // timer has actually reached zero, ticking the *display* forever isn't
+    // enough: nothing else re-triggers reconciliation, so the countdown
+    // would otherwise freeze at 00:00 indefinitely instead of resolving
+    // the attack and arming the next one. Route through the real reload in
+    // that case.
     _countdownRefreshTimer = Timer.periodic(
-      const Duration(seconds: 30),
-      (_) => setState(() {}),
+      const Duration(seconds: 1),
+      (_) {
+        if (!mounted) return;
+        final cubit = context.read<TodosOverviewCubit>();
+        final now = DateTime.now();
+        final hasExpiredAttackTimer = cubit.state.activeEncounter?.enemies
+                .any((enemy) {
+              final timer = cubit.state.attackTimerFor(enemy);
+              return timer != null && !timer.nextTriggerAt.isAfter(now);
+            }) ??
+            false;
+        if (hasExpiredAttackTimer) {
+          cubit.loadCharacter();
+        } else {
+          setState(() {});
+        }
+      },
     );
   }
 

--- a/lib/cubits/todo_tab/todos_overview/combat_status_card.dart
+++ b/lib/cubits/todo_tab/todos_overview/combat_status_card.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -7,8 +8,10 @@ import 'package:questvale/cubits/todo_tab/todos_overview/todos_overview_cubit.da
 import 'package:questvale/cubits/todo_tab/todos_overview/todos_overview_state.dart';
 import 'package:questvale/data/models/character.dart';
 import 'package:questvale/data/models/enemy.dart';
+import 'package:questvale/data/models/scheduled_timer.dart';
 import 'package:questvale/data/providers/game_data_models/enemy_data.dart';
 import 'package:questvale/helpers/constants.dart';
+import 'package:questvale/helpers/data_formatters.dart';
 import 'package:questvale/helpers/shared_enums.dart';
 import 'package:questvale/widgets/qv_button.dart';
 import 'package:questvale/widgets/qv_bar.dart';
@@ -16,12 +19,12 @@ import 'package:questvale/widgets/qv_card_border.dart';
 import 'package:questvale/widgets/qv_inset_background.dart';
 
 // Scaffold for the character/combat status block pinned above the todo
-// list. XP (level/currentExp), health/AP/mana, and in-combat enemy state
-// read real data from TodosOverviewCubit. Skill cooldowns, enemy attack
-// timers, and the XP bar's exp-to-next-level threshold have no real system
-// behind them yet (no leveling curve exists anywhere in the codebase), so
-// those are placeholder values laid out so the real systems can slot in
-// later.
+// list. XP (level/currentExp), health/AP/mana, in-combat enemy state, and
+// enemy attack countdowns read real data from TodosOverviewCubit. Skill
+// cooldowns and the XP bar's exp-to-next-level threshold still have no real
+// system behind them (no leveling curve or live cooldown tracking exists
+// anywhere in the codebase yet), so those remain placeholder values laid
+// out so the real systems can slot in later.
 class CombatStatusCard extends StatefulWidget {
   const CombatStatusCard({super.key});
 
@@ -39,6 +42,7 @@ class _CombatStatusCardState extends State<CombatStatusCard> {
 
   late final List<ButtonColor> _placeholderSkillColors;
   late final List<Duration> _placeholderSkillCooldowns;
+  Timer? _countdownRefreshTimer;
 
   @override
   void initState() {
@@ -62,6 +66,20 @@ class _CombatStatusCardState extends State<CombatStatusCard> {
     // Guarantee at least one ready (no-cooldown) slot so both rectangle
     // styles are represented.
     _placeholderSkillCooldowns[random.nextInt(_skillSlotCount)] = Duration.zero;
+
+    // Purely presentational — recomputes nextTriggerAt - now() on a plain
+    // UI timer, no business logic here. Hour/day-scale timers don't need
+    // per-second precision, per the scheduling engine's UI countdown notes.
+    _countdownRefreshTimer = Timer.periodic(
+      const Duration(seconds: 30),
+      (_) => setState(() {}),
+    );
+  }
+
+  @override
+  void dispose() {
+    _countdownRefreshTimer?.cancel();
+    super.dispose();
   }
 
   @override
@@ -362,23 +380,6 @@ class _CharacterVitalsRow extends StatelessWidget {
   }
 }
 
-// Countdown display shared by skill cooldowns and enemy attack timers: hh:mm
-// once there's at least an hour left, dropping to mm:ss once it's down to
-// minutes so the last stretch reads with second-level precision.
-String _formatCountdown(Duration remaining) {
-  final totalSeconds = remaining.inSeconds;
-  String pad(int n) => n.toString().padLeft(2, '0');
-  if (totalSeconds >= Duration.secondsPerHour) {
-    final hours = totalSeconds ~/ Duration.secondsPerHour;
-    final minutes =
-        (totalSeconds % Duration.secondsPerHour) ~/ Duration.secondsPerMinute;
-    return '${pad(hours)}:${pad(minutes)}';
-  }
-  final minutes = totalSeconds ~/ Duration.secondsPerMinute;
-  final seconds = totalSeconds % Duration.secondsPerMinute;
-  return '${pad(minutes)}:${pad(seconds)}';
-}
-
 // Row 2 — 5 skill-cooldown buttons. Placeholder colors/cooldowns only; no
 // live skill-cooldown tracking exists yet (see class doc comment above).
 class _SkillCooldownRow extends StatelessWidget {
@@ -423,7 +424,7 @@ class _SkillCooldownSlot extends StatelessWidget {
       child: Center(
         child: onCooldown
             ? Text(
-                _formatCountdown(cooldown),
+                DataFormatters.formatCountdown(cooldown),
                 style: const TextStyle(
                   color: Colors.white,
                   fontSize: 16,
@@ -458,6 +459,7 @@ class _CombatEnemiesSection extends StatelessWidget {
                     .map((enemy) => _EnemyCombatBlock(
                           enemy: enemy,
                           enemyData: state.enemyDataFor(enemy),
+                          attackTimer: state.attackTimerFor(enemy),
                         ))
                     .toList(),
               ),
@@ -477,43 +479,22 @@ class _CombatEnemiesSection extends StatelessWidget {
   }
 }
 
-// Placeholder for the enemy's next-move type — no such system exists yet
-// (see class doc comment above); this stands in for whatever real enum
-// eventually classifies an enemy move as attack/buff/debuff/etc.
-enum _EnemyMoveType {
-  attack,
-  buff,
-  debuff;
-
-  String get label {
-    switch (this) {
-      case _EnemyMoveType.attack:
-        return 'Attack';
-      case _EnemyMoveType.buff:
-        return 'Buff';
-      case _EnemyMoveType.debuff:
-        return 'Debuff';
-    }
-  }
-}
-
 class _EnemyCombatBlock extends StatelessWidget {
   final Enemy enemy;
   final EnemyData? enemyData;
-  const _EnemyCombatBlock({required this.enemy, required this.enemyData});
+  final ScheduledTimer? attackTimer;
+  const _EnemyCombatBlock(
+      {required this.enemy, required this.enemyData, required this.attackTimer});
 
   @override
   Widget build(BuildContext context) {
     final isDead = enemy.currentHealth <= 0;
-    // Stable per-enemy placeholders (seeded off the enemy id, salted
-    // differently per field so they don't move in lockstep) so neither
-    // jumps around on every reload — no live attack-timer or move-type
-    // system exists yet. Attacks land on an hours-scale cadence, not
-    // seconds.
-    final placeholderAttackTime =
-        Duration(seconds: Random(enemy.id.hashCode).nextInt(24 * 3600) + 1);
-    final placeholderMoveType = _EnemyMoveType.values[
-        Random(enemy.id.hashCode + 1).nextInt(_EnemyMoveType.values.length)];
+    final now = DateTime.now();
+    final attackCountdown = attackTimer == null
+        ? null
+        : (attackTimer!.nextTriggerAt.isAfter(now)
+            ? attackTimer!.nextTriggerAt.difference(now)
+            : Duration.zero);
 
     final colorScheme = Theme.of(context).colorScheme;
     return Opacity(
@@ -559,27 +540,36 @@ class _EnemyCombatBlock extends StatelessWidget {
                             fontWeight: FontWeight.w600,
                           ),
                         )
-                      : Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              placeholderMoveType.label,
+                      : attackTimer == null || attackCountdown == null
+                          ? Text(
+                              '—',
                               style: TextStyle(
                                 color: Colors.white.withValues(alpha: 0.7),
-                                fontSize: 12,
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                            Text(
-                              _formatCountdown(placeholderAttackTime),
-                              style: const TextStyle(
-                                color: Colors.white,
                                 fontSize: 16,
                                 fontWeight: FontWeight.w600,
                               ),
+                            )
+                          : Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  attackTimer!.payload,
+                                  style: TextStyle(
+                                    color: Colors.white.withValues(alpha: 0.7),
+                                    fontSize: 12,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                Text(
+                                  DataFormatters.formatCountdown(attackCountdown),
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ],
                             ),
-                          ],
-                        ),
                 ),
               ),
             ],

--- a/lib/cubits/todo_tab/todos_overview/todos_overview_cubit.dart
+++ b/lib/cubits/todo_tab/todos_overview/todos_overview_cubit.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:questvale/cubits/home/player_cubit.dart';
 import 'package:questvale/cubits/todo_tab/todos_overview/todos_overview_state.dart';
+import 'package:questvale/data/models/scheduled_timer.dart';
 import 'package:questvale/data/models/todo.dart';
 import 'package:questvale/data/models/tag.dart';
 import 'package:questvale/data/providers/game_data.dart';
@@ -10,6 +11,7 @@ import 'package:questvale/data/repositories/character_repository.dart';
 import 'package:questvale/data/repositories/encounter_repository.dart';
 import 'package:questvale/data/repositories/quest_repository.dart';
 import 'package:questvale/services/ap_reward_service.dart';
+import 'package:questvale/services/enemy_attack_scheduling_service.dart';
 import 'package:questvale/services/habit_service.dart';
 import 'package:questvale/services/notification_service.dart';
 
@@ -20,6 +22,7 @@ class TodosOverviewCubit extends Cubit<TodosOverviewState> {
   final EncounterRepository encounterRepository;
   final GameData gameData;
   final PlayerCubit playerCubit;
+  final EnemyAttackSchedulingService enemyAttackSchedulingService;
   late final HabitService habitService;
   late final ApRewardService apRewardService;
 
@@ -29,7 +32,8 @@ class TodosOverviewCubit extends Cubit<TodosOverviewState> {
       this.questRepository,
       this.encounterRepository,
       this.gameData,
-      this.playerCubit)
+      this.playerCubit,
+      this.enemyAttackSchedulingService)
       : super(const TodosOverviewState()) {
     habitService = HabitService();
     apRewardService = ApRewardService(gameData: gameData);
@@ -62,10 +66,28 @@ class TodosOverviewCubit extends Cubit<TodosOverviewState> {
         ? gameData.questZones.firstWhereOrNull((z) => z.id == quest.zoneId)
         : null;
 
+    // Reconcile any enemy attacks that came due while the app wasn't open —
+    // same "checked on every load" idiom as _advanceHabitPeriodIfNeeded
+    // above, rather than a dedicated app-lifecycle/background-timer hook.
+    var reconciledCharacter = character;
+    Map<String, ScheduledTimer> attackTimers = const {};
+    if (encounter != null &&
+        encounter.completedAt == null &&
+        encounter.encounterType.isCombatEncounter()) {
+      final reconciliation = await enemyAttackSchedulingService.reconcile(
+        encounter: encounter,
+        character: reconciledCharacter,
+        enemyDataFor: (enemy) => questZone?.enemies
+            .firstWhereOrNull((data) => data.id == enemy.enemyDataId),
+      );
+      reconciledCharacter = reconciliation.character;
+      attackTimers = reconciliation.attackTimersByEnemyId;
+    }
+
     if (!isClosed) {
       emit(
         TodosOverviewState(
-          character: character,
+          character: reconciledCharacter,
           characterStats: stats,
           todos: todos,
           availableTags: availableTags
@@ -81,6 +103,7 @@ class TodosOverviewCubit extends Cubit<TodosOverviewState> {
           viewMode: state.viewMode,
           activeEncounter: encounter,
           activeQuestZone: questZone,
+          enemyAttackTimers: attackTimers,
         ),
       );
     }

--- a/lib/cubits/todo_tab/todos_overview/todos_overview_cubit.dart
+++ b/lib/cubits/todo_tab/todos_overview/todos_overview_cubit.dart
@@ -71,6 +71,7 @@ class TodosOverviewCubit extends Cubit<TodosOverviewState> {
     // above, rather than a dedicated app-lifecycle/background-timer hook.
     var reconciledCharacter = character;
     Map<String, ScheduledTimer> attackTimers = const {};
+    int? damageTaken;
     if (encounter != null &&
         encounter.completedAt == null &&
         encounter.encounterType.isCombatEncounter()) {
@@ -82,6 +83,9 @@ class TodosOverviewCubit extends Cubit<TodosOverviewState> {
       );
       reconciledCharacter = reconciliation.character;
       attackTimers = reconciliation.attackTimersByEnemyId;
+      damageTaken = reconciliation.totalDamageDealt > 0
+          ? reconciliation.totalDamageDealt
+          : null;
     }
 
     if (!isClosed) {
@@ -104,6 +108,7 @@ class TodosOverviewCubit extends Cubit<TodosOverviewState> {
           activeEncounter: encounter,
           activeQuestZone: questZone,
           enemyAttackTimers: attackTimers,
+          lastEnemyDamageTaken: damageTaken,
         ),
       );
     }

--- a/lib/cubits/todo_tab/todos_overview/todos_overview_page.dart
+++ b/lib/cubits/todo_tab/todos_overview/todos_overview_page.dart
@@ -9,6 +9,7 @@ import 'package:questvale/data/repositories/todo_repository.dart';
 import 'package:questvale/data/repositories/character_repository.dart';
 import 'package:questvale/data/repositories/encounter_repository.dart';
 import 'package:questvale/data/repositories/quest_repository.dart';
+import 'package:questvale/services/enemy_attack_scheduling_service.dart';
 import 'package:sqflite/sqflite.dart';
 
 class TodosOverviewPage extends StatelessWidget {
@@ -26,6 +27,7 @@ class TodosOverviewPage extends StatelessWidget {
             EncounterRepository(db: context.read<Database>()),
             context.read<GameData>(),
             context.read<PlayerCubit>(),
+            EnemyAttackSchedulingService(db: context.read<Database>()),
           ),
         ),
         BlocProvider(create: (context) => TodosCalendarCubit()),

--- a/lib/cubits/todo_tab/todos_overview/todos_overview_state.dart
+++ b/lib/cubits/todo_tab/todos_overview/todos_overview_state.dart
@@ -4,6 +4,7 @@ import 'package:questvale/data/models/character.dart';
 import 'package:questvale/data/models/character_stats.dart';
 import 'package:questvale/data/models/encounter.dart';
 import 'package:questvale/data/models/enemy.dart';
+import 'package:questvale/data/models/scheduled_timer.dart';
 import 'package:questvale/data/models/todo.dart';
 import 'package:questvale/data/models/tag.dart';
 import 'package:questvale/data/providers/game_data_models/enemy_data.dart';
@@ -76,6 +77,11 @@ class TodosOverviewState extends Equatable {
   final Encounter? activeEncounter;
   final QuestZone? activeQuestZone;
 
+  // Real, live enemy-attack timers for the current encounter, keyed by
+  // Enemy.id — reconciled on every load in TodosOverviewCubit.loadCharacter.
+  // Empty (not just absent) when not in combat.
+  final Map<String, ScheduledTimer> enemyAttackTimers;
+
   const TodosOverviewState({
     this.character,
     this.characterStats,
@@ -88,6 +94,7 @@ class TodosOverviewState extends Equatable {
     this.viewMode = TodosViewMode.list,
     this.activeEncounter,
     this.activeQuestZone,
+    this.enemyAttackTimers = const {},
   });
 
   TodosOverviewState copyWith({
@@ -110,6 +117,7 @@ class TodosOverviewState extends Equatable {
       viewMode: viewMode ?? this.viewMode,
       activeEncounter: activeEncounter,
       activeQuestZone: activeQuestZone,
+      enemyAttackTimers: enemyAttackTimers,
     );
   }
 
@@ -122,6 +130,8 @@ class TodosOverviewState extends Equatable {
 
   EnemyData? enemyDataFor(Enemy enemy) => activeQuestZone?.enemies
       .firstWhereOrNull((data) => data.id == enemy.enemyDataId);
+
+  ScheduledTimer? attackTimerFor(Enemy enemy) => enemyAttackTimers[enemy.id];
 
   // "Today"/"This Week" are scoped by due date but don't hide completed
   // items — per the design, completion only dims a row; only the active
@@ -225,5 +235,6 @@ class TodosOverviewState extends Equatable {
         viewMode,
         activeEncounter,
         activeQuestZone,
+        enemyAttackTimers,
       ];
 }

--- a/lib/cubits/todo_tab/todos_overview/todos_overview_state.dart
+++ b/lib/cubits/todo_tab/todos_overview/todos_overview_state.dart
@@ -82,6 +82,12 @@ class TodosOverviewState extends Equatable {
   // Empty (not just absent) when not in combat.
   final Map<String, ScheduledTimer> enemyAttackTimers;
 
+  // Total HP just lost to enemy attacks resolved by the most recent
+  // loadCharacter() call — null when that call resolved no attacks. A
+  // BlocListener uses this to fire a one-shot damage-taken toast; it's not
+  // "current damage state" so much as an event riding along on this emit.
+  final int? lastEnemyDamageTaken;
+
   const TodosOverviewState({
     this.character,
     this.characterStats,
@@ -95,6 +101,7 @@ class TodosOverviewState extends Equatable {
     this.activeEncounter,
     this.activeQuestZone,
     this.enemyAttackTimers = const {},
+    this.lastEnemyDamageTaken,
   });
 
   TodosOverviewState copyWith({
@@ -118,6 +125,7 @@ class TodosOverviewState extends Equatable {
       activeEncounter: activeEncounter,
       activeQuestZone: activeQuestZone,
       enemyAttackTimers: enemyAttackTimers,
+      lastEnemyDamageTaken: lastEnemyDamageTaken,
     );
   }
 
@@ -236,5 +244,6 @@ class TodosOverviewState extends Equatable {
         activeEncounter,
         activeQuestZone,
         enemyAttackTimers,
+        lastEnemyDamageTaken,
       ];
 }

--- a/lib/cubits/todo_tab/todos_overview/todos_overview_view.dart
+++ b/lib/cubits/todo_tab/todos_overview/todos_overview_view.dart
@@ -16,6 +16,7 @@ import 'package:questvale/data/models/todo.dart';
 import 'package:questvale/widgets/qv_app_bar.dart';
 import 'package:questvale/widgets/qv_background.dart';
 import 'package:questvale/widgets/qv_button.dart';
+import 'package:questvale/widgets/qv_damage_toast.dart';
 import 'package:questvale/widgets/qv_fading_scrollable.dart';
 
 class TodosOverviewView extends StatelessWidget {
@@ -28,14 +29,26 @@ class TodosOverviewView extends StatelessWidget {
     final todoCubit = context.read<TodosOverviewCubit>();
     ColorScheme colorScheme = Theme.of(context).colorScheme;
 
-    return BlocListener<NavCubit, NavState>(
-      // The World tab is where combat actually happens, and IndexedStack
-      // keeps every tab mounted forever — TodosOverviewCubit's quest/
-      // encounter snapshot (feeding CombatStatusCard's enemy row) would
-      // otherwise go stale the moment the player leaves and returns.
-      listenWhen: (previous, current) =>
-          current.tab == _todoTabIndex && previous.tab != _todoTabIndex,
-      listener: (context, state) => todoCubit.loadCharacter(),
+    return MultiBlocListener(
+      listeners: [
+        BlocListener<NavCubit, NavState>(
+          // The World tab is where combat actually happens, and
+          // IndexedStack keeps every tab mounted forever —
+          // TodosOverviewCubit's quest/encounter snapshot (feeding
+          // CombatStatusCard's enemy row) would otherwise go stale the
+          // moment the player leaves and returns.
+          listenWhen: (previous, current) =>
+              current.tab == _todoTabIndex && previous.tab != _todoTabIndex,
+          listener: (context, state) => todoCubit.loadCharacter(),
+        ),
+        BlocListener<TodosOverviewCubit, TodosOverviewState>(
+          listenWhen: (previous, current) =>
+              current.lastEnemyDamageTaken != null &&
+              current.lastEnemyDamageTaken != previous.lastEnemyDamageTaken,
+          listener: (context, state) =>
+              showDamageToast(context, state.lastEnemyDamageTaken!),
+        ),
+      ],
       child: Scaffold(
         floatingActionButton: QvButton(
           width: 60,

--- a/lib/cubits/world_tab/questing/combat/combat_cubit.dart
+++ b/lib/cubits/world_tab/questing/combat/combat_cubit.dart
@@ -1,26 +1,43 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:questvale/cubits/home/player_cubit.dart';
 import 'package:questvale/cubits/world_tab/questing/combat/combat_state.dart';
 import 'package:questvale/data/models/enemy.dart';
+import 'package:questvale/data/providers/game_data_models/quest_zone.dart';
 import 'package:questvale/data/providers/game_data_models/skill_data.dart';
+import 'package:questvale/data/repositories/character_repository.dart';
+import 'package:questvale/data/repositories/encounter_repository.dart';
 import 'package:questvale/data/repositories/enemy_repository.dart';
 import 'package:questvale/data/repositories/scheduled_timer_repository.dart';
 import 'package:questvale/data/skills/base_active_skill.dart';
 import 'package:questvale/services/combat_service.dart';
+import 'package:questvale/services/enemy_attack_scheduling_service.dart';
 import 'package:sqflite/sqflite.dart';
 
 class CombatCubit extends Cubit<CombatState> {
   final String encounterId;
+  final QuestZone questZone;
+  final PlayerCubit playerCubit;
   late EnemyRepository enemyRepository;
   late ScheduledTimerRepository scheduledTimerRepository;
+  late EncounterRepository encounterRepository;
+  late CharacterRepository characterRepository;
   late CombatService combatService;
+  late EnemyAttackSchedulingService enemyAttackSchedulingService;
 
-  CombatCubit({required this.encounterId, required Database db})
+  CombatCubit(
+      {required this.encounterId,
+      required this.questZone,
+      required this.playerCubit,
+      required Database db})
       : super(CombatState(enemies: [])) {
     enemyRepository = EnemyRepository(db: db);
     scheduledTimerRepository = ScheduledTimerRepository(db: db);
+    encounterRepository = EncounterRepository(db: db);
+    characterRepository = CharacterRepository(db: db);
     combatService = CombatService(db: db);
+    enemyAttackSchedulingService = EnemyAttackSchedulingService(db: db);
     init();
   }
 
@@ -28,10 +45,25 @@ class CombatCubit extends Cubit<CombatState> {
     reload();
   }
 
+  // Reloading also reconciles any overdue enemy attack timers (same engine
+  // TodosOverviewCubit uses) rather than just re-reading whatever's in the
+  // DB — otherwise an attack timer that expires while this page is open
+  // would sit frozen at zero forever, since nothing else in this cubit's
+  // tree ever resolves it. playerCubit.loadCharacter() keeps the HP/mana
+  // bars at the bottom of this page in sync with any damage reconciliation
+  // just applied.
   Future<void> reload() async {
-    final enemies = await enemyRepository.getEnemiesByEncounterId(encounterId);
-    final timers =
-        await scheduledTimerRepository.getTimersByEncounterId(encounterId);
+    final encounter = await encounterRepository.getEncounterById(encounterId);
+    final character = await characterRepository.getSingleCharacter();
+    final reconciliation = await enemyAttackSchedulingService.reconcile(
+      encounter: encounter,
+      character: character,
+      enemyDataFor: (enemy) => questZone.enemies
+          .firstWhereOrNull((data) => data.id == enemy.enemyDataId),
+    );
+    await playerCubit.loadCharacter();
+
+    final enemies = encounter.enemies;
     CombatStatus newStatus = state.status;
     if (state.status != CombatStatus.complete) {
       if (enemies.every((enemy) => enemy.currentHealth <= 0)) {
@@ -47,7 +79,7 @@ class CombatCubit extends Cubit<CombatState> {
         targetingSkill: null,
         target: SkillTarget.none,
         inspectingEnemyIndex: -1,
-        attackTimers: {for (final t in timers) t.ownerId: t},
+        attackTimers: reconciliation.attackTimersByEnemyId,
       ));
     }
   }

--- a/lib/cubits/world_tab/questing/combat/combat_cubit.dart
+++ b/lib/cubits/world_tab/questing/combat/combat_cubit.dart
@@ -5,6 +5,7 @@ import 'package:questvale/cubits/world_tab/questing/combat/combat_state.dart';
 import 'package:questvale/data/models/enemy.dart';
 import 'package:questvale/data/providers/game_data_models/skill_data.dart';
 import 'package:questvale/data/repositories/enemy_repository.dart';
+import 'package:questvale/data/repositories/scheduled_timer_repository.dart';
 import 'package:questvale/data/skills/base_active_skill.dart';
 import 'package:questvale/services/combat_service.dart';
 import 'package:sqflite/sqflite.dart';
@@ -12,11 +13,13 @@ import 'package:sqflite/sqflite.dart';
 class CombatCubit extends Cubit<CombatState> {
   final String encounterId;
   late EnemyRepository enemyRepository;
+  late ScheduledTimerRepository scheduledTimerRepository;
   late CombatService combatService;
 
   CombatCubit({required this.encounterId, required Database db})
       : super(CombatState(enemies: [])) {
     enemyRepository = EnemyRepository(db: db);
+    scheduledTimerRepository = ScheduledTimerRepository(db: db);
     combatService = CombatService(db: db);
     init();
   }
@@ -27,6 +30,8 @@ class CombatCubit extends Cubit<CombatState> {
 
   Future<void> reload() async {
     final enemies = await enemyRepository.getEnemiesByEncounterId(encounterId);
+    final timers =
+        await scheduledTimerRepository.getTimersByEncounterId(encounterId);
     CombatStatus newStatus = state.status;
     if (state.status != CombatStatus.complete) {
       if (enemies.every((enemy) => enemy.currentHealth <= 0)) {
@@ -42,6 +47,7 @@ class CombatCubit extends Cubit<CombatState> {
         targetingSkill: null,
         target: SkillTarget.none,
         inspectingEnemyIndex: -1,
+        attackTimers: {for (final t in timers) t.ownerId: t},
       ));
     }
   }

--- a/lib/cubits/world_tab/questing/combat/combat_cubit.dart
+++ b/lib/cubits/world_tab/questing/combat/combat_cubit.dart
@@ -80,6 +80,9 @@ class CombatCubit extends Cubit<CombatState> {
         target: SkillTarget.none,
         inspectingEnemyIndex: -1,
         attackTimers: reconciliation.attackTimersByEnemyId,
+        lastEnemyDamageTaken: reconciliation.totalDamageDealt > 0
+            ? reconciliation.totalDamageDealt
+            : null,
       ));
     }
   }

--- a/lib/cubits/world_tab/questing/combat/combat_page.dart
+++ b/lib/cubits/world_tab/questing/combat/combat_page.dart
@@ -22,6 +22,7 @@ import 'package:questvale/widgets/qv_animated_transition.dart';
 import 'package:questvale/widgets/qv_blinking.dart';
 import 'package:questvale/widgets/qv_button.dart';
 import 'package:questvale/widgets/qv_card_border.dart';
+import 'package:questvale/widgets/qv_damage_toast.dart';
 import 'package:questvale/widgets/qv_fading_scrollable.dart';
 import 'package:questvale/widgets/qv_inset_background.dart';
 import 'package:questvale/widgets/qv_metal_corner_border.dart';
@@ -63,15 +64,26 @@ class CombatView extends StatelessWidget {
     final themeId = context.watch<ThemeCubit>().state.theme.id;
     return BlocBuilder<CombatCubit, CombatState>(
         builder: (context, combatState) {
-      return BlocListener<CombatCubit, CombatState>(
-        listenWhen: (prev, next) =>
-            prev.status != CombatStatus.complete &&
-            next.status == CombatStatus.complete,
-        listener: (context, combatState) async {
-          if (combatState.status == CombatStatus.complete) {
-            await context.read<QuestEncounterCubit>().completeEncounter();
-          }
-        },
+      return MultiBlocListener(
+        listeners: [
+          BlocListener<CombatCubit, CombatState>(
+            listenWhen: (prev, next) =>
+                prev.status != CombatStatus.complete &&
+                next.status == CombatStatus.complete,
+            listener: (context, combatState) async {
+              if (combatState.status == CombatStatus.complete) {
+                await context.read<QuestEncounterCubit>().completeEncounter();
+              }
+            },
+          ),
+          BlocListener<CombatCubit, CombatState>(
+            listenWhen: (prev, next) =>
+                next.lastEnemyDamageTaken != null &&
+                next.lastEnemyDamageTaken != prev.lastEnemyDamageTaken,
+            listener: (context, combatState) =>
+                showDamageToast(context, combatState.lastEnemyDamageTaken!),
+          ),
+        ],
         child: BlocBuilder<PlayerCubit, PlayerState>(
             builder: (context, playerState) {
           final character = playerState.character;

--- a/lib/cubits/world_tab/questing/combat/combat_page.dart
+++ b/lib/cubits/world_tab/questing/combat/combat_page.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:questvale/cubits/home/player_cubit.dart';
@@ -8,9 +11,13 @@ import 'package:questvale/cubits/world_tab/questing/quest_encounter/quest_encoun
 import 'package:questvale/cubits/world_tab/questing/quest_encounter/quest_flee_confirmation_modal.dart';
 import 'package:questvale/cubits/theme/theme_cubit.dart';
 import 'package:questvale/data/models/enemy.dart';
+import 'package:questvale/data/models/scheduled_timer.dart';
+import 'package:questvale/data/providers/game_data_models/enemy_attack_data.dart';
+import 'package:questvale/data/providers/game_data_models/enemy_data.dart';
 import 'package:questvale/data/providers/game_data_models/skill_data.dart';
 import 'package:questvale/data/skills/base_active_skill.dart';
 import 'package:questvale/helpers/constants.dart';
+import 'package:questvale/helpers/data_formatters.dart';
 import 'package:questvale/widgets/qv_animated_transition.dart';
 import 'package:questvale/widgets/qv_blinking.dart';
 import 'package:questvale/widgets/qv_button.dart';
@@ -617,7 +624,13 @@ class EnemyInfoBox extends StatelessWidget {
                 child: SingleChildScrollView(
                   child: Column(
                     children: [
-                      EnemyNextAttackSlice(),
+                      EnemyNextAttackSlice(
+                        attackTimer: context
+                            .read<CombatCubit>()
+                            .state
+                            .attackTimerFor(enemy),
+                        enemyData: enemyData,
+                      ),
                       EnemyStatusEffectsSlice(),
                       Text(enemyData.rarity.name.toUpperCase()),
                       Text(enemyData.enemyType.name.toUpperCase()),
@@ -662,13 +675,56 @@ class EnemyInfoBox extends StatelessWidget {
   }
 }
 
-class EnemyNextAttackSlice extends StatelessWidget {
-  const EnemyNextAttackSlice({super.key});
+class EnemyNextAttackSlice extends StatefulWidget {
+  final ScheduledTimer? attackTimer;
+  final EnemyData enemyData;
+
+  const EnemyNextAttackSlice(
+      {super.key, required this.attackTimer, required this.enemyData});
+
+  @override
+  State<EnemyNextAttackSlice> createState() => _EnemyNextAttackSliceState();
+}
+
+class _EnemyNextAttackSliceState extends State<EnemyNextAttackSlice> {
+  Timer? _countdownRefreshTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    // Purely presentational — recomputes nextTriggerAt - now() on a plain
+    // UI timer while this box is open, no business logic here. Hour/day
+    // -scale timers don't need per-second precision.
+    _countdownRefreshTimer = Timer.periodic(
+      const Duration(seconds: 30),
+      (_) => setState(() {}),
+    );
+  }
+
+  @override
+  void dispose() {
+    _countdownRefreshTimer?.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     ColorScheme colorScheme = Theme.of(context).colorScheme;
     final themeId = context.watch<ThemeCubit>().state.theme.id;
+
+    final timer = widget.attackTimer;
+    EnemyAttackData? attack;
+    String countdownLabel = '—';
+    if (timer != null) {
+      final now = DateTime.now();
+      final remaining = timer.nextTriggerAt.isAfter(now)
+          ? timer.nextTriggerAt.difference(now)
+          : Duration.zero;
+      countdownLabel = DataFormatters.formatCountdown(remaining);
+      attack = widget.enemyData.attacks
+          .firstWhereOrNull((a) => a.name == timer.payload);
+    }
+
     return Column(
       children: [
         Align(
@@ -699,7 +755,7 @@ class EnemyNextAttackSlice extends StatelessWidget {
             direction: Axis.horizontal,
             children: [
               Expanded(
-                  child: Text('1:12',
+                  child: Text(countdownLabel,
                       style: TextStyle(
                           fontSize: 20, color: Colors.grey[100], height: 1),
                       textAlign: TextAlign.center)),
@@ -708,12 +764,12 @@ class EnemyNextAttackSlice extends StatelessWidget {
               Expanded(
                   flex: 3,
                   child: Text(
-                    'Slam',
+                    attack?.name ?? '—',
                     style: TextStyle(
                         fontSize: 20, color: colorScheme.primary, height: 1),
                   )),
               Expanded(
-                  child: Text('8-12',
+                  child: Text(attack == null ? '—' : '${attack.damage}',
                       style: TextStyle(
                           fontSize: 20, color: colorScheme.primary, height: 1),
                       textAlign: TextAlign.center)),

--- a/lib/cubits/world_tab/questing/combat/combat_page.dart
+++ b/lib/cubits/world_tab/questing/combat/combat_page.dart
@@ -37,8 +37,12 @@ class CombatPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider<CombatCubit>(
-        create: (context) =>
-            CombatCubit(encounterId: encounterId, db: context.read<Database>()),
+        create: (context) => CombatCubit(
+              encounterId: encounterId,
+              questZone: context.read<QuestEncounterCubit>().questZone,
+              playerCubit: context.read<PlayerCubit>(),
+              db: context.read<Database>(),
+            ),
         child: const CombatView());
   }
 }
@@ -692,12 +696,24 @@ class _EnemyNextAttackSliceState extends State<EnemyNextAttackSlice> {
   @override
   void initState() {
     super.initState();
-    // Purely presentational — recomputes nextTriggerAt - now() on a plain
-    // UI timer while this box is open, no business logic here. Hour/day
-    // -scale timers don't need per-second precision.
+    // Recomputes nextTriggerAt - now() every second, so the countdown
+    // visibly ticks down rather than jumping in chunks — purely
+    // presentational when nothing has expired yet. But once the timer has
+    // actually reached zero, ticking the display alone would freeze it at
+    // 00:00 forever: nothing else re-triggers reconciliation while this
+    // box is open. Route through CombatCubit.reload() (which reconciles)
+    // instead.
     _countdownRefreshTimer = Timer.periodic(
-      const Duration(seconds: 30),
-      (_) => setState(() {}),
+      const Duration(seconds: 1),
+      (_) {
+        if (!mounted) return;
+        final timer = widget.attackTimer;
+        if (timer != null && !timer.nextTriggerAt.isAfter(DateTime.now())) {
+          context.read<CombatCubit>().reload();
+        } else {
+          setState(() {});
+        }
+      },
     );
   }
 

--- a/lib/cubits/world_tab/questing/combat/combat_state.dart
+++ b/lib/cubits/world_tab/questing/combat/combat_state.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:questvale/data/models/enemy.dart';
+import 'package:questvale/data/models/scheduled_timer.dart';
 import 'package:questvale/data/skills/base_active_skill.dart';
 
 enum CombatStatus {
@@ -43,13 +44,20 @@ class CombatState extends Equatable {
   final BaseActiveSkill? targetingSkill;
   final int inspectingEnemyIndex;
 
+  // Real enemy-attack timers for this encounter, keyed by Enemy.id —
+  // reloaded alongside enemies in CombatCubit.reload().
+  final Map<String, ScheduledTimer> attackTimers;
+
   const CombatState({
     required this.enemies,
     this.status = CombatStatus.idle,
     this.target = SkillTarget.none,
     this.targetingSkill,
     this.inspectingEnemyIndex = -1,
+    this.attackTimers = const {},
   });
+
+  ScheduledTimer? attackTimerFor(Enemy enemy) => attackTimers[enemy.id];
 
   CombatState copyWith({
     List<Enemy>? enemies,
@@ -57,6 +65,7 @@ class CombatState extends Equatable {
     SkillTarget? target,
     BaseActiveSkill? targetingSkill,
     int? inspectingEnemyIndex,
+    Map<String, ScheduledTimer>? attackTimers,
   }) {
     return CombatState(
         enemies: enemies ?? this.enemies,
@@ -64,10 +73,17 @@ class CombatState extends Equatable {
         target: target ?? this.target,
         targetingSkill: targetingSkill ?? this.targetingSkill,
         inspectingEnemyIndex:
-            inspectingEnemyIndex ?? this.inspectingEnemyIndex);
+            inspectingEnemyIndex ?? this.inspectingEnemyIndex,
+        attackTimers: attackTimers ?? this.attackTimers);
   }
 
   @override
-  List<Object?> get props =>
-      [enemies, status, target, targetingSkill, inspectingEnemyIndex];
+  List<Object?> get props => [
+        enemies,
+        status,
+        target,
+        targetingSkill,
+        inspectingEnemyIndex,
+        attackTimers
+      ];
 }

--- a/lib/cubits/world_tab/questing/combat/combat_state.dart
+++ b/lib/cubits/world_tab/questing/combat/combat_state.dart
@@ -48,6 +48,11 @@ class CombatState extends Equatable {
   // reloaded alongside enemies in CombatCubit.reload().
   final Map<String, ScheduledTimer> attackTimers;
 
+  // Total HP just lost to enemy attacks resolved by the most recent
+  // reload() call — null when that call resolved no attacks. A
+  // BlocListener uses this to fire a one-shot damage-taken toast.
+  final int? lastEnemyDamageTaken;
+
   const CombatState({
     required this.enemies,
     this.status = CombatStatus.idle,
@@ -55,10 +60,16 @@ class CombatState extends Equatable {
     this.targetingSkill,
     this.inspectingEnemyIndex = -1,
     this.attackTimers = const {},
+    this.lastEnemyDamageTaken,
   });
 
   ScheduledTimer? attackTimerFor(Enemy enemy) => attackTimers[enemy.id];
 
+  // lastEnemyDamageTaken deliberately isn't merged with `?? this.field` like
+  // the rest of these — it's a one-shot event, not persistent state, so
+  // every copyWith call resets it to whatever's passed (null if omitted)
+  // rather than carrying an old damage amount forward indefinitely. Only
+  // reload() ever passes a real value for it.
   CombatState copyWith({
     List<Enemy>? enemies,
     CombatStatus? status,
@@ -66,6 +77,7 @@ class CombatState extends Equatable {
     BaseActiveSkill? targetingSkill,
     int? inspectingEnemyIndex,
     Map<String, ScheduledTimer>? attackTimers,
+    int? lastEnemyDamageTaken,
   }) {
     return CombatState(
         enemies: enemies ?? this.enemies,
@@ -74,7 +86,8 @@ class CombatState extends Equatable {
         targetingSkill: targetingSkill ?? this.targetingSkill,
         inspectingEnemyIndex:
             inspectingEnemyIndex ?? this.inspectingEnemyIndex,
-        attackTimers: attackTimers ?? this.attackTimers);
+        attackTimers: attackTimers ?? this.attackTimers,
+        lastEnemyDamageTaken: lastEnemyDamageTaken);
   }
 
   @override
@@ -84,6 +97,7 @@ class CombatState extends Equatable {
         target,
         targetingSkill,
         inspectingEnemyIndex,
-        attackTimers
+        attackTimers,
+        lastEnemyDamageTaken,
       ];
 }

--- a/lib/cubits/world_tab/questing/quest_encounter/quest_encounter_cubit.dart
+++ b/lib/cubits/world_tab/questing/quest_encounter/quest_encounter_cubit.dart
@@ -9,6 +9,7 @@ import 'package:questvale/data/repositories/encounter_repository.dart';
 import 'package:questvale/data/repositories/enemy_repository.dart';
 import 'package:questvale/data/repositories/quest_repository.dart';
 import 'package:questvale/services/enemy_attack_scheduling_service.dart';
+import 'package:questvale/services/notification_service.dart';
 import 'package:questvale/services/quest_service.dart';
 import 'package:sqflite/sqflite.dart';
 
@@ -156,11 +157,25 @@ class QuestEncounterCubit extends Cubit<QuestEncounterState> {
     }
   }
 
+  // Cancels any still-pending attack-incoming notifications for `encounterId`
+  // before clearing its ScheduledTimers, so a defeated/abandoned encounter's
+  // enemies can't notify the player about an attack that will never land.
+  Future<void> _clearEncounterTimers(String encounterId) async {
+    final timers = await enemyAttackSchedulingService.scheduledTimerRepository
+        .getTimersByEncounterId(encounterId);
+    for (final timer in timers) {
+      await NotificationService().cancelEnemyAttackWarning(timer.id);
+    }
+    await enemyAttackSchedulingService.scheduledTimerRepository
+        .deleteTimersByEncounterId(encounterId);
+  }
+
   Future<void> _cleanEncounter() async {
     final quest = state.quest;
     final encounter = await encounterRepository.getEncounterByQuestId(quest.id);
     if (encounter != null) {
       await enemyRepository.deleteEnemiesByEncounterId(encounter.id);
+      await _clearEncounterTimers(encounter.id);
       await encounterRepository.deleteEncounter(encounter);
     }
   }
@@ -180,6 +195,7 @@ class QuestEncounterCubit extends Cubit<QuestEncounterState> {
     if (encounter != null) {
       await encounterRepository.deleteEncounter(encounter);
       await enemyRepository.deleteEnemiesByEncounterId(encounter.id);
+      await _clearEncounterTimers(encounter.id);
     }
     emit(state.copyWith(questStatus: QuestStatus.questDeleted));
   }

--- a/lib/cubits/world_tab/questing/quest_encounter/quest_encounter_cubit.dart
+++ b/lib/cubits/world_tab/questing/quest_encounter/quest_encounter_cubit.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:questvale/cubits/world_tab/questing/quest_encounter/quest_encounter_state.dart';
 import 'package:questvale/data/models/encounter.dart';
@@ -7,6 +8,7 @@ import 'package:questvale/data/repositories/character_repository.dart';
 import 'package:questvale/data/repositories/encounter_repository.dart';
 import 'package:questvale/data/repositories/enemy_repository.dart';
 import 'package:questvale/data/repositories/quest_repository.dart';
+import 'package:questvale/services/enemy_attack_scheduling_service.dart';
 import 'package:questvale/services/quest_service.dart';
 import 'package:sqflite/sqflite.dart';
 
@@ -16,6 +18,7 @@ class QuestEncounterCubit extends Cubit<QuestEncounterState> {
   late EncounterRepository encounterRepository;
   late EnemyRepository enemyRepository;
   late CharacterRepository characterRepository;
+  late EnemyAttackSchedulingService enemyAttackSchedulingService;
 
   final QuestZone questZone;
 
@@ -31,6 +34,7 @@ class QuestEncounterCubit extends Cubit<QuestEncounterState> {
     enemyRepository = EnemyRepository(db: db);
     characterRepository = CharacterRepository(db: db);
     questService = QuestService(db: db);
+    enemyAttackSchedulingService = EnemyAttackSchedulingService(db: db);
     init();
   }
 
@@ -83,6 +87,15 @@ class QuestEncounterCubit extends Cubit<QuestEncounterState> {
     await encounterRepository.insertEncounter(newEncounter);
     for (var enemy in newEncounter.enemies) {
       await enemyRepository.insertEnemy(enemy);
+      final enemyData =
+          questZone.enemies.firstWhereOrNull((d) => d.id == enemy.enemyDataId);
+      if (enemyData != null) {
+        await enemyAttackSchedulingService.scheduleNextMove(
+          enemy: enemy,
+          enemyData: enemyData,
+          encounter: newEncounter,
+        );
+      }
     }
     return newEncounter;
   }

--- a/lib/data/models/scheduled_timer.dart
+++ b/lib/data/models/scheduled_timer.dart
@@ -1,0 +1,107 @@
+// The shared time-based scheduling primitive — see the vault's
+// "Time-Based Scheduling Engine" architecture note. One record shape is
+// meant to eventually cover enemy moves, status effect duration/ticks, and
+// player skill cooldowns; only enemyMove is a real consumer so far.
+enum ScheduledTimerKind {
+  enemyMove;
+}
+
+class ScheduledTimer {
+  static const String scheduledTimerTableName = 'ScheduledTimers';
+
+  static const String idColumnName = 'id';
+  static const String ownerIdColumnName = 'ownerId';
+  static const String encounterIdColumnName = 'encounterId';
+  static const String kindColumnName = 'kind';
+  static const String payloadColumnName = 'payload';
+  static const String remainingWorkMsColumnName = 'remainingWorkMs';
+  static const String segmentStartedAtColumnName = 'segmentStartedAt';
+  static const String currentRateColumnName = 'currentRate';
+  static const String nextTriggerAtColumnName = 'nextTriggerAt';
+  static const String recurringColumnName = 'recurring';
+
+  static const createTableSQL = '''
+    CREATE TABLE $scheduledTimerTableName (
+      $idColumnName VARCHAR PRIMARY KEY,
+      $ownerIdColumnName VARCHAR NOT NULL,
+      $encounterIdColumnName VARCHAR NOT NULL,
+      $kindColumnName INTEGER NOT NULL,
+      $payloadColumnName VARCHAR NOT NULL,
+      $remainingWorkMsColumnName INTEGER NOT NULL,
+      $segmentStartedAtColumnName INTEGER NOT NULL,
+      $currentRateColumnName REAL NOT NULL DEFAULT 1.0,
+      $nextTriggerAtColumnName INTEGER NOT NULL,
+      $recurringColumnName INTEGER NOT NULL DEFAULT 0
+    );
+  ''';
+
+  final String id;
+  final String ownerId;
+  final String encounterId;
+  final ScheduledTimerKind kind;
+  final String payload;
+  final int remainingWorkMs;
+  final DateTime segmentStartedAt;
+  final double currentRate;
+  final DateTime nextTriggerAt;
+  final bool recurring;
+
+  const ScheduledTimer({
+    required this.id,
+    required this.ownerId,
+    required this.encounterId,
+    required this.kind,
+    required this.payload,
+    required this.remainingWorkMs,
+    required this.segmentStartedAt,
+    this.currentRate = 1.0,
+    required this.nextTriggerAt,
+    this.recurring = false,
+  });
+
+  Map<String, Object?> toMap() {
+    return {
+      idColumnName: id,
+      ownerIdColumnName: ownerId,
+      encounterIdColumnName: encounterId,
+      kindColumnName: kind.index,
+      payloadColumnName: payload,
+      remainingWorkMsColumnName: remainingWorkMs,
+      segmentStartedAtColumnName: segmentStartedAt.millisecondsSinceEpoch,
+      currentRateColumnName: currentRate,
+      nextTriggerAtColumnName: nextTriggerAt.millisecondsSinceEpoch,
+      recurringColumnName: recurring ? 1 : 0,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'ScheduledTimer(id: $id, ownerId: $ownerId, encounterId: $encounterId, kind: $kind, payload: $payload, remainingWorkMs: $remainingWorkMs, segmentStartedAt: $segmentStartedAt, currentRate: $currentRate, nextTriggerAt: $nextTriggerAt, recurring: $recurring)';
+  }
+
+  ScheduledTimer copyWith({
+    String? id,
+    String? ownerId,
+    String? encounterId,
+    ScheduledTimerKind? kind,
+    String? payload,
+    int? remainingWorkMs,
+    DateTime? segmentStartedAt,
+    double? currentRate,
+    DateTime? nextTriggerAt,
+    bool? recurring,
+  }) {
+    return ScheduledTimer(
+      id: id ?? this.id,
+      ownerId: ownerId ?? this.ownerId,
+      encounterId: encounterId ?? this.encounterId,
+      kind: kind ?? this.kind,
+      payload: payload ?? this.payload,
+      remainingWorkMs: remainingWorkMs ?? this.remainingWorkMs,
+      segmentStartedAt: segmentStartedAt ?? this.segmentStartedAt,
+      currentRate: currentRate ?? this.currentRate,
+      nextTriggerAt: nextTriggerAt ?? this.nextTriggerAt,
+      recurring: recurring ?? this.recurring,
+    );
+  }
+}

--- a/lib/data/questvale_db.dart
+++ b/lib/data/questvale_db.dart
@@ -8,6 +8,7 @@ import 'package:questvale/data/models/enemy.dart';
 import 'package:questvale/data/models/equipment.dart';
 import 'package:questvale/data/models/equipment_encounter_reward.dart';
 import 'package:questvale/data/models/quest.dart';
+import 'package:questvale/data/models/scheduled_timer.dart';
 import 'package:questvale/data/models/stat_modifier.dart';
 import 'package:questvale/data/models/todo.dart';
 import 'package:questvale/data/models/todo_tag.dart';
@@ -77,6 +78,7 @@ class QuestvaleDB {
       await db.execute(StatModifier.createTableSQL);
 
       await db.execute(Enemy.createTableSQL);
+      await db.execute(ScheduledTimer.createTableSQL);
     }, onUpgrade: (db, oldVersion, newVersion) async {
       // TodoTag/CharacterTag were never added to a version-gated migration
       // block when the tags feature shipped, so any install that upgraded
@@ -183,6 +185,9 @@ class QuestvaleDB {
         await db.execute(
             'ALTER TABLE ${Character.characterTableName} ADD COLUMN ${Character.combatStatusCardExpandedColumnName} BOOLEAN NOT NULL DEFAULT 1');
       }
-    }, version: 11);
+      if (oldVersion < 12) {
+        await db.execute(ScheduledTimer.createTableSQL);
+      }
+    }, version: 12);
   }
 }

--- a/lib/data/repositories/scheduled_timer_repository.dart
+++ b/lib/data/repositories/scheduled_timer_repository.dart
@@ -1,0 +1,72 @@
+import 'package:questvale/data/models/scheduled_timer.dart';
+import 'package:sqflite/sqflite.dart';
+
+class ScheduledTimerRepository {
+  final Database db;
+
+  ScheduledTimerRepository({required this.db});
+
+  // GET TIMERS BY ENCOUNTER ID
+  Future<List<ScheduledTimer>> getTimersByEncounterId(
+      String encounterId) async {
+    final List<Map<String, dynamic>> maps = await db.query(
+        ScheduledTimer.scheduledTimerTableName,
+        where: '${ScheduledTimer.encounterIdColumnName} = ?',
+        whereArgs: [encounterId]);
+    return maps.map(_getTimerFromMap).toList();
+  }
+
+  // GET THE (AT MOST ONE) ACTIVE TIMER FOR AN OWNER + KIND
+  Future<ScheduledTimer?> getTimerForOwner(
+      String ownerId, ScheduledTimerKind kind) async {
+    final result = await db.query(
+      ScheduledTimer.scheduledTimerTableName,
+      where:
+          '${ScheduledTimer.ownerIdColumnName} = ? AND ${ScheduledTimer.kindColumnName} = ?',
+      whereArgs: [ownerId, kind.index],
+    );
+    if (result.isEmpty) return null;
+    return _getTimerFromMap(result.first);
+  }
+
+  // INSERT TIMER
+  Future<void> insertTimer(ScheduledTimer timer) async {
+    await db.insert(ScheduledTimer.scheduledTimerTableName, timer.toMap());
+  }
+
+  // UPDATE TIMER
+  Future<void> updateTimer(ScheduledTimer timer) async {
+    await db.update(ScheduledTimer.scheduledTimerTableName, timer.toMap(),
+        where: '${ScheduledTimer.idColumnName} = ?', whereArgs: [timer.id]);
+  }
+
+  // DELETE ALL TIMERS OWNED BY A GIVEN OWNER (e.g. an enemy that died)
+  Future<void> deleteTimersByOwnerId(String ownerId) async {
+    await db.delete(ScheduledTimer.scheduledTimerTableName,
+        where: '${ScheduledTimer.ownerIdColumnName} = ?', whereArgs: [ownerId]);
+  }
+
+  // DELETE ALL TIMERS FOR AN ENCOUNTER (e.g. on encounter completion)
+  Future<void> deleteTimersByEncounterId(String encounterId) async {
+    await db.delete(ScheduledTimer.scheduledTimerTableName,
+        where: '${ScheduledTimer.encounterIdColumnName} = ?',
+        whereArgs: [encounterId]);
+  }
+
+  ScheduledTimer _getTimerFromMap(Map<String, Object?> map) {
+    return ScheduledTimer(
+      id: map[ScheduledTimer.idColumnName] as String,
+      ownerId: map[ScheduledTimer.ownerIdColumnName] as String,
+      encounterId: map[ScheduledTimer.encounterIdColumnName] as String,
+      kind: ScheduledTimerKind.values[map[ScheduledTimer.kindColumnName] as int],
+      payload: map[ScheduledTimer.payloadColumnName] as String,
+      remainingWorkMs: map[ScheduledTimer.remainingWorkMsColumnName] as int,
+      segmentStartedAt: DateTime.fromMillisecondsSinceEpoch(
+          map[ScheduledTimer.segmentStartedAtColumnName] as int),
+      currentRate: (map[ScheduledTimer.currentRateColumnName] as num).toDouble(),
+      nextTriggerAt: DateTime.fromMillisecondsSinceEpoch(
+          map[ScheduledTimer.nextTriggerAtColumnName] as int),
+      recurring: (map[ScheduledTimer.recurringColumnName] as int) == 1,
+    );
+  }
+}

--- a/lib/helpers/data_formatters.dart
+++ b/lib/helpers/data_formatters.dart
@@ -78,6 +78,24 @@ class DataFormatters {
 
   static String weekdayName(int weekday) => _weekdayNames[weekday - 1];
 
+  // Shared by any hour/day-scale countdown display (skill cooldowns, enemy
+  // attack timers): hh:mm once there's at least an hour left, dropping to
+  // mm:ss once it's down to minutes so the last stretch reads with
+  // second-level precision.
+  static String formatCountdown(Duration remaining) {
+    final totalSeconds = remaining.inSeconds;
+    String pad(int n) => n.toString().padLeft(2, '0');
+    if (totalSeconds >= Duration.secondsPerHour) {
+      final hours = totalSeconds ~/ Duration.secondsPerHour;
+      final minutes =
+          (totalSeconds % Duration.secondsPerHour) ~/ Duration.secondsPerMinute;
+      return '${pad(hours)}:${pad(minutes)}';
+    }
+    final minutes = totalSeconds ~/ Duration.secondsPerMinute;
+    final seconds = totalSeconds % Duration.secondsPerMinute;
+    return '${pad(minutes)}:${pad(seconds)}';
+  }
+
   static String formatRepeatInterval(int interval, HabitTimeframe timeframe) {
     String unit;
     switch (timeframe) {

--- a/lib/services/combat_service.dart
+++ b/lib/services/combat_service.dart
@@ -1,5 +1,7 @@
+import 'package:questvale/data/models/character.dart';
 import 'package:questvale/data/models/enemy.dart';
 import 'package:questvale/data/models/player_combat_stats.dart';
+import 'package:questvale/data/providers/game_data_models/enemy_attack_data.dart';
 import 'package:questvale/data/providers/game_data_models/skill_data.dart';
 import 'package:questvale/data/repositories/character_repository.dart';
 import 'package:questvale/data/repositories/enemy_repository.dart';
@@ -47,5 +49,18 @@ class CombatService {
     if (newHealth <= 0) didKill = true;
     await enemyRepository.updateEnemy(enemy.copyWith(currentHealth: newHealth));
     return DamageResult(damageDone: damageDone, didKill: didKill);
+  }
+
+  // Enemy -> player direction, fired when a ScheduledTimer resolves (see
+  // EnemyAttackSchedulingService). Flat damage straight off the static
+  // attack data, matching applyDamage's existing lack of stat recalculation
+  // above rather than inventing a separate defense formula here.
+  Future<Character> applyEnemyAttackDamage(
+      EnemyAttackData attack, Character character) async {
+    final newHealth = (character.currentHealth - attack.damage)
+        .clamp(0, character.maxHealth)
+        .toInt();
+    final updated = character.copyWith(currentHealth: newHealth);
+    return await characterRepository.updateCharacter(updated);
   }
 }

--- a/lib/services/combat_service.dart
+++ b/lib/services/combat_service.dart
@@ -55,12 +55,25 @@ class CombatService {
   // EnemyAttackSchedulingService). Flat damage straight off the static
   // attack data, matching applyDamage's existing lack of stat recalculation
   // above rather than inventing a separate defense formula here.
-  Future<Character> applyEnemyAttackDamage(
+  Future<EnemyAttackDamageResult> applyEnemyAttackDamage(
       EnemyAttackData attack, Character character) async {
     final newHealth = (character.currentHealth - attack.damage)
         .clamp(0, character.maxHealth)
         .toInt();
+    // The amount actually taken, not the raw attack stat — clamped at 0 HP
+    // means a killing blow can deal less than its listed damage.
+    final damageDealt = character.currentHealth - newHealth;
     final updated = character.copyWith(currentHealth: newHealth);
-    return await characterRepository.updateCharacter(updated);
+    final persisted = await characterRepository.updateCharacter(updated);
+    return EnemyAttackDamageResult(
+        character: persisted, damageDealt: damageDealt);
   }
+}
+
+class EnemyAttackDamageResult {
+  final Character character;
+  final int damageDealt;
+
+  EnemyAttackDamageResult(
+      {required this.character, required this.damageDealt});
 }

--- a/lib/services/enemy_attack_scheduling_service.dart
+++ b/lib/services/enemy_attack_scheduling_service.dart
@@ -1,0 +1,232 @@
+import 'dart:math';
+
+import 'package:questvale/data/models/character.dart';
+import 'package:questvale/data/models/encounter.dart';
+import 'package:questvale/data/models/enemy.dart';
+import 'package:questvale/data/models/scheduled_timer.dart';
+import 'package:questvale/data/providers/game_data_models/enemy_attack_data.dart';
+import 'package:questvale/data/providers/game_data_models/enemy_data.dart';
+import 'package:questvale/data/repositories/scheduled_timer_repository.dart';
+import 'package:questvale/services/combat_service.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:uuid/uuid.dart';
+
+// The result of reconciling an encounter's overdue enemy-attack timers: the
+// character after every overdue attack has been applied, plus each living
+// enemy's now-current (or freshly (re)armed) timer, keyed by Enemy.id.
+class ReconciliationResult {
+  final Character character;
+  final Map<String, ScheduledTimer> attackTimersByEnemyId;
+
+  ReconciliationResult(
+      {required this.character, required this.attackTimersByEnemyId});
+}
+
+// Builds and replays ScheduledTimers (kind: enemyMove) for enemy attacks —
+// the concrete engine described in the vault's "Time-Based Scheduling
+// Engine" note, scoped to enemy attacks only. Pure scheduling/segment math
+// lives in top-level functions/static methods so it can be unit tested
+// without a database; scheduleNextMove/reconcile are the DB-touching
+// wrappers around that math.
+class EnemyAttackSchedulingService {
+  final Database db;
+  late final ScheduledTimerRepository scheduledTimerRepository;
+  late final CombatService combatService;
+
+  EnemyAttackSchedulingService({required this.db}) {
+    scheduledTimerRepository = ScheduledTimerRepository(db: db);
+    combatService = CombatService(db: db);
+  }
+
+  // Weighted-random pick from an enemy's moveset using EnemyAttackData's
+  // existing (previously unconsumed) `weight` field. Falls back to a
+  // uniform pick if every weight is zero/negative, so a bad data entry
+  // can't make move selection dead-end with no move chosen.
+  static EnemyAttackData selectMove(
+      List<EnemyAttackData> attacks, Random random) {
+    if (attacks.isEmpty) {
+      throw ArgumentError('Cannot select a move from an empty attack list');
+    }
+    final totalWeight = attacks.fold<double>(0, (sum, a) => sum + a.weight);
+    if (totalWeight <= 0) {
+      return attacks[random.nextInt(attacks.length)];
+    }
+    var roll = random.nextDouble() * totalWeight;
+    for (final attack in attacks) {
+      roll -= attack.weight;
+      if (roll <= 0) return attack;
+    }
+    return attacks.last;
+  }
+
+  // Builds a fresh, unpersisted timer for `move` starting at `now`, at
+  // 1.0x rate (no rate modifier producer exists yet). EnemyAttackData's
+  // `cooldown` is in hours, matching the hours-scale cadence already
+  // assumed by combat_status_card.dart's (placeholder) countdown display.
+  static ScheduledTimer buildInitialTimer({
+    required Enemy enemy,
+    required String encounterId,
+    required EnemyAttackData move,
+    required DateTime now,
+    required String id,
+  }) {
+    final remainingWorkMs = (move.cooldown * Duration.millisecondsPerHour).round();
+    return ScheduledTimer(
+      id: id,
+      ownerId: enemy.id,
+      encounterId: encounterId,
+      kind: ScheduledTimerKind.enemyMove,
+      payload: move.name,
+      remainingWorkMs: remainingWorkMs,
+      segmentStartedAt: now,
+      currentRate: 1.0,
+      nextTriggerAt: now.add(Duration(milliseconds: remainingWorkMs)),
+      recurring: false,
+    );
+  }
+
+  // Closes the timer's current segment as of `at` (progress made under its
+  // existing currentRate) and opens a new one under `newRate`, recomputing
+  // nextTriggerAt from there. Nothing in production calls this with a rate
+  // other than 1.0 yet (no Slow/Freeze producer exists), but the math is
+  // written generically per the architecture note so a future rate-modifier
+  // producer can plug in without touching this engine's core.
+  static ScheduledTimer recomputeSegment({
+    required ScheduledTimer timer,
+    required double newRate,
+    required DateTime at,
+  }) {
+    final elapsedInSegmentMs = at.difference(timer.segmentStartedAt).inMilliseconds;
+    final consumedMs = (elapsedInSegmentMs * timer.currentRate).round();
+    final remainingWorkMs = max(0, timer.remainingWorkMs - consumedMs);
+    // A rate of 0 (e.g. a future Freeze) halts the timer entirely rather
+    // than firing it — represented as an effectively-unreachable deadline
+    // rather than dividing by zero.
+    final wallClockForRemainder = newRate <= 0
+        ? const Duration(days: 3650)
+        : Duration(milliseconds: (remainingWorkMs / newRate).round());
+    return timer.copyWith(
+      remainingWorkMs: remainingWorkMs,
+      segmentStartedAt: at,
+      currentRate: newRate,
+      nextTriggerAt: at.add(wallClockForRemainder),
+    );
+  }
+
+  // Finds the single soonest overdue timer (nextTriggerAt <= now) across
+  // `timers`, or null if nothing is due. The core of the chronological
+  // replay requirement — reconcile() calls this once per iteration rather
+  // than resolving every overdue timer against a single elapsed-time
+  // subtraction, so multiple overdue events always process oldest-first.
+  static ScheduledTimer? nextDueTimer(List<ScheduledTimer> timers, DateTime now) {
+    final due = timers.where((t) => !t.nextTriggerAt.isAfter(now)).toList()
+      ..sort((a, b) => a.nextTriggerAt.compareTo(b.nextTriggerAt));
+    return due.isEmpty ? null : due.first;
+  }
+
+  // Picks a move for `enemy` and persists a fresh timer for it, replacing
+  // any stale one that owner already had (e.g. re-arming after an attack).
+  Future<ScheduledTimer> scheduleNextMove({
+    required Enemy enemy,
+    required EnemyData enemyData,
+    required Encounter encounter,
+    DateTime? from,
+    Random? random,
+  }) async {
+    final move = selectMove(enemyData.attacks, random ?? Random());
+    final timer = buildInitialTimer(
+      enemy: enemy,
+      encounterId: encounter.id,
+      move: move,
+      now: from ?? DateTime.now(),
+      id: Uuid().v4(),
+    );
+    final existing = await scheduledTimerRepository.getTimerForOwner(
+        enemy.id, ScheduledTimerKind.enemyMove);
+    if (existing != null) {
+      await scheduledTimerRepository.updateTimer(timer.copyWith(id: existing.id));
+      return timer.copyWith(id: existing.id);
+    }
+    await scheduledTimerRepository.insertTimer(timer);
+    return timer;
+  }
+
+  // The replay engine: processes every ScheduledTimer for `encounter` whose
+  // nextTriggerAt has passed, in chronological order (never a single
+  // elapsed-time subtraction), applying damage and re-arming each enemy's
+  // next move as it goes. Safe to call on every load — a no-op when
+  // nothing is overdue.
+  Future<ReconciliationResult> reconcile({
+    required Encounter encounter,
+    required Character character,
+    required EnemyData? Function(Enemy enemy) enemyDataFor,
+    Random? random,
+  }) async {
+    final enemiesById = {for (final e in encounter.enemies) e.id: e};
+    var timers = await scheduledTimerRepository.getTimersByEncounterId(encounter.id);
+    var currentCharacter = character;
+    final now = DateTime.now();
+
+    // Self-heals any living enemy with no timer at all — e.g. an encounter
+    // already in progress when this feature shipped, so spawn-time
+    // scheduling never ran for it. Scheduled from `now` since there's no
+    // missed deadline to chain from.
+    final ownedIds = timers.map((t) => t.ownerId).toSet();
+    for (final enemy in encounter.enemies) {
+      if (enemy.currentHealth <= 0 || ownedIds.contains(enemy.id)) continue;
+      final enemyData = enemyDataFor(enemy);
+      if (enemyData == null || enemyData.attacks.isEmpty) continue;
+      final timer = await scheduleNextMove(
+        enemy: enemy,
+        enemyData: enemyData,
+        encounter: encounter,
+        from: now,
+        random: random,
+      );
+      timers = [...timers, timer];
+    }
+
+    while (true) {
+      final due = nextDueTimer(timers, now);
+      if (due == null) break;
+      final enemy = enemiesById[due.ownerId];
+      timers = timers.where((t) => t.id != due.id).toList();
+
+      if (enemy == null || enemy.currentHealth <= 0) {
+        // Dead/missing enemies don't get to land a last hit from a stale
+        // timer — just clear it.
+        await scheduledTimerRepository.deleteTimersByOwnerId(due.ownerId);
+        continue;
+      }
+
+      final enemyData = enemyDataFor(enemy);
+      if (enemyData == null || enemyData.attacks.isEmpty) {
+        await scheduledTimerRepository.deleteTimersByOwnerId(due.ownerId);
+        continue;
+      }
+      final attack = enemyData.attacks.firstWhere(
+        (a) => a.name == due.payload,
+        orElse: () => enemyData.attacks.first,
+      );
+
+      currentCharacter =
+          await combatService.applyEnemyAttackDamage(attack, currentCharacter);
+
+      // Chain from the missed deadline rather than `now`, so a long-closed
+      // app doesn't grant the enemy's next attack a grace-period bonus.
+      final nextTimer = await scheduleNextMove(
+        enemy: enemy,
+        enemyData: enemyData,
+        encounter: encounter,
+        from: due.nextTriggerAt,
+        random: random,
+      );
+      timers = [...timers, nextTimer];
+    }
+
+    return ReconciliationResult(
+      character: currentCharacter,
+      attackTimersByEnemyId: {for (final t in timers) t.ownerId: t},
+    );
+  }
+}

--- a/lib/services/enemy_attack_scheduling_service.dart
+++ b/lib/services/enemy_attack_scheduling_service.dart
@@ -13,14 +13,19 @@ import 'package:sqflite/sqflite.dart';
 import 'package:uuid/uuid.dart';
 
 // The result of reconciling an encounter's overdue enemy-attack timers: the
-// character after every overdue attack has been applied, plus each living
-// enemy's now-current (or freshly (re)armed) timer, keyed by Enemy.id.
+// character after every overdue attack has been applied, each living
+// enemy's now-current (or freshly (re)armed) timer keyed by Enemy.id, and
+// the total HP actually lost across every attack resolved by this call (0
+// when nothing was due) — callers use that to show a damage-taken toast.
 class ReconciliationResult {
   final Character character;
   final Map<String, ScheduledTimer> attackTimersByEnemyId;
+  final int totalDamageDealt;
 
   ReconciliationResult(
-      {required this.character, required this.attackTimersByEnemyId});
+      {required this.character,
+      required this.attackTimersByEnemyId,
+      this.totalDamageDealt = 0});
 }
 
 // Builds and replays ScheduledTimers (kind: enemyMove) for enemy attacks —
@@ -190,6 +195,7 @@ class EnemyAttackSchedulingService {
     final enemiesById = {for (final e in encounter.enemies) e.id: e};
     var timers = await scheduledTimerRepository.getTimersByEncounterId(encounter.id);
     var currentCharacter = character;
+    var totalDamageDealt = 0;
     final now = DateTime.now();
 
     // Self-heals any living enemy with no timer at all — e.g. an encounter
@@ -236,8 +242,10 @@ class EnemyAttackSchedulingService {
         orElse: () => enemyData.attacks.first,
       );
 
-      currentCharacter =
+      final damageResult =
           await combatService.applyEnemyAttackDamage(attack, currentCharacter);
+      currentCharacter = damageResult.character;
+      totalDamageDealt += damageResult.damageDealt;
 
       // Chain from `now`, not the missed deadline — see the reconcile()
       // doc-comment. This is what caps the enemy to one resolved attack per
@@ -255,6 +263,7 @@ class EnemyAttackSchedulingService {
     return ReconciliationResult(
       character: currentCharacter,
       attackTimersByEnemyId: {for (final t in timers) t.ownerId: t},
+      totalDamageDealt: totalDamageDealt,
     );
   }
 }

--- a/lib/services/enemy_attack_scheduling_service.dart
+++ b/lib/services/enemy_attack_scheduling_service.dart
@@ -8,6 +8,7 @@ import 'package:questvale/data/providers/game_data_models/enemy_attack_data.dart
 import 'package:questvale/data/providers/game_data_models/enemy_data.dart';
 import 'package:questvale/data/repositories/scheduled_timer_repository.dart';
 import 'package:questvale/services/combat_service.dart';
+import 'package:questvale/services/notification_service.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:uuid/uuid.dart';
 
@@ -29,6 +30,11 @@ class ReconciliationResult {
 // without a database; scheduleNextMove/reconcile are the DB-touching
 // wrappers around that math.
 class EnemyAttackSchedulingService {
+  // Copy isn't the point for this pass (per the ticket) — generic content,
+  // enemy name included since it's already on hand. Not user-configurable
+  // yet; a settings UI for lead time is explicitly out of scope.
+  static const attackWarningLeadTime = Duration(minutes: 15);
+
   final Database db;
   late final ScheduledTimerRepository scheduledTimerRepository;
   late final CombatService combatService;
@@ -126,6 +132,9 @@ class EnemyAttackSchedulingService {
 
   // Picks a move for `enemy` and persists a fresh timer for it, replacing
   // any stale one that owner already had (e.g. re-arming after an attack).
+  // Also (re)schedules the attack-incoming notification for this timer —
+  // this is the single choke point used for both initial spawn scheduling
+  // and every re-arm, so timer and notification lifecycles always match.
   Future<ScheduledTimer> scheduleNextMove({
     required Enemy enemy,
     required EnemyData enemyData,
@@ -143,19 +152,35 @@ class EnemyAttackSchedulingService {
     );
     final existing = await scheduledTimerRepository.getTimerForOwner(
         enemy.id, ScheduledTimerKind.enemyMove);
+    final ScheduledTimer persisted;
     if (existing != null) {
-      await scheduledTimerRepository.updateTimer(timer.copyWith(id: existing.id));
-      return timer.copyWith(id: existing.id);
+      persisted = timer.copyWith(id: existing.id);
+      await scheduledTimerRepository.updateTimer(persisted);
+    } else {
+      persisted = timer;
+      await scheduledTimerRepository.insertTimer(persisted);
     }
-    await scheduledTimerRepository.insertTimer(timer);
-    return timer;
+    await NotificationService().scheduleEnemyAttackWarning(
+      persisted,
+      leadTime: attackWarningLeadTime,
+      title: 'Enemy Attack Incoming',
+      body: '${enemyData.name} is about to attack!',
+    );
+    return persisted;
   }
 
-  // The replay engine: processes every ScheduledTimer for `encounter` whose
-  // nextTriggerAt has passed, in chronological order (never a single
-  // elapsed-time subtraction), applying damage and re-arming each enemy's
-  // next move as it goes. Safe to call on every load — a no-op when
-  // nothing is overdue.
+  // The replay engine: processes each living enemy's overdue ScheduledTimer
+  // (nextTriggerAt has passed), applying damage and re-arming its next move
+  // chained from `now` — not from the missed deadline. That cap is
+  // deliberate: an enemy resolves at most one attack per reconcile() call
+  // no matter how long the app was closed, so a missed day (or several)
+  // costs exactly one hit rather than compounding every elapsed cooldown
+  // cycle into a pile of damage the moment the player returns. It's also
+  // what guarantees at most one ScheduledTimer — and so at most one
+  // attack-incoming notification — is ever pending per enemy at a time.
+  // Multiple simultaneously-overdue enemies are still each resolved, still
+  // soonest-first via nextDueTimer(). Safe to call on every load — a no-op
+  // when nothing is overdue.
   Future<ReconciliationResult> reconcile({
     required Encounter encounter,
     required Character character,
@@ -194,13 +219,15 @@ class EnemyAttackSchedulingService {
 
       if (enemy == null || enemy.currentHealth <= 0) {
         // Dead/missing enemies don't get to land a last hit from a stale
-        // timer — just clear it.
+        // timer — just clear it (and any warning notification riding on it).
+        await NotificationService().cancelEnemyAttackWarning(due.id);
         await scheduledTimerRepository.deleteTimersByOwnerId(due.ownerId);
         continue;
       }
 
       final enemyData = enemyDataFor(enemy);
       if (enemyData == null || enemyData.attacks.isEmpty) {
+        await NotificationService().cancelEnemyAttackWarning(due.id);
         await scheduledTimerRepository.deleteTimersByOwnerId(due.ownerId);
         continue;
       }
@@ -212,13 +239,14 @@ class EnemyAttackSchedulingService {
       currentCharacter =
           await combatService.applyEnemyAttackDamage(attack, currentCharacter);
 
-      // Chain from the missed deadline rather than `now`, so a long-closed
-      // app doesn't grant the enemy's next attack a grace-period bonus.
+      // Chain from `now`, not the missed deadline — see the reconcile()
+      // doc-comment. This is what caps the enemy to one resolved attack per
+      // reconcile() call regardless of how overdue it was.
       final nextTimer = await scheduleNextMove(
         enemy: enemy,
         enemyData: enemyData,
         encounter: encounter,
-        from: due.nextTriggerAt,
+        from: now,
         random: random,
       );
       timers = [...timers, nextTimer];

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:questvale/data/models/scheduled_timer.dart';
 import 'package:questvale/data/models/todo_reminder.dart';
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
@@ -13,6 +14,9 @@ class NotificationService {
 
   static const _androidChannelId = 'todo_reminders';
   static const _androidChannelName = 'Task & Habit Reminders';
+
+  static const _enemyAttackChannelId = 'enemy_attack_warnings';
+  static const _enemyAttackChannelName = 'Enemy Attack Warnings';
 
   final FlutterLocalNotificationsPlugin _plugin =
       FlutterLocalNotificationsPlugin();
@@ -78,5 +82,43 @@ class NotificationService {
     await _plugin.cancel(_notificationId(reminderId));
   }
 
-  int _notificationId(String reminderId) => reminderId.hashCode & 0x7fffffff;
+  // Warns before an enemy's ScheduledTimer (see EnemyAttackSchedulingService)
+  // fires. Reconciliation caps an enemy to at most one pending timer at a
+  // time and always chains its id forward across re-arms (see
+  // scheduleNextMove), so scheduling under `timer.id` here naturally
+  // replaces the previous warning for that enemy — no separate bookkeeping
+  // needed to know "does this enemy already have one scheduled."
+  Future<void> scheduleEnemyAttackWarning(
+    ScheduledTimer timer, {
+    required Duration leadTime,
+    required String title,
+    String? body,
+  }) async {
+    final fireAt = timer.nextTriggerAt.subtract(leadTime);
+    if (fireAt.isBefore(DateTime.now())) return;
+
+    await _plugin.zonedSchedule(
+      _notificationId(timer.id),
+      title,
+      body,
+      tz.TZDateTime.from(fireAt, tz.UTC),
+      const NotificationDetails(
+        android: AndroidNotificationDetails(
+          _enemyAttackChannelId,
+          _enemyAttackChannelName,
+          channelDescription: 'Warnings before an enemy attacks',
+          importance: Importance.high,
+          priority: Priority.high,
+        ),
+        iOS: DarwinNotificationDetails(),
+      ),
+      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
+    );
+  }
+
+  Future<void> cancelEnemyAttackWarning(String timerId) async {
+    await _plugin.cancel(_notificationId(timerId));
+  }
+
+  int _notificationId(String id) => id.hashCode & 0x7fffffff;
 }

--- a/lib/widgets/qv_damage_toast.dart
+++ b/lib/widgets/qv_damage_toast.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:questvale/widgets/qv_button.dart';
+
+// Shows a transient "- N HP" pill about a third of the way down the screen,
+// for when an enemy attack resolves and damages the player — the same
+// fire-and-forget shape as QvApToast (qv_ap_toast.dart), just styled as a
+// hit taken rather than AP gained.
+void showDamageToast(BuildContext context, int amount) {
+  final overlay = Overlay.of(context);
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (context) => _DamageToast(
+      amount: amount,
+      onDone: () => entry.remove(),
+    ),
+  );
+  overlay.insert(entry);
+}
+
+class _DamageToast extends StatefulWidget {
+  final int amount;
+  final VoidCallback onDone;
+
+  const _DamageToast({required this.amount, required this.onDone});
+
+  @override
+  State<_DamageToast> createState() => _DamageToastState();
+}
+
+class _DamageToastState extends State<_DamageToast>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+  late final Animation<double> _translateY;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1750),
+    );
+    _opacity = TweenSequence<double>([
+      TweenSequenceItem(tween: Tween(begin: 0.0, end: 1.0), weight: 12),
+      TweenSequenceItem(tween: ConstantTween(1.0), weight: 48),
+      TweenSequenceItem(tween: Tween(begin: 1.0, end: 0.0), weight: 40),
+    ]).animate(_controller);
+    _translateY = TweenSequence<double>([
+      TweenSequenceItem(tween: ConstantTween(0.0), weight: 60),
+      TweenSequenceItem(
+        tween: Tween(begin: 0.0, end: 30.0).chain(CurveTween(curve: Curves.easeIn)),
+        weight: 40,
+      ),
+    ]).animate(_controller);
+    _controller.forward().whenComplete(widget.onDone);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
+
+    return Positioned(
+      bottom: screenHeight / 5,
+      left: 0,
+      right: 0,
+      child: IgnorePointer(
+        child: Center(
+          child: AnimatedBuilder(
+            animation: _controller,
+            builder: (context, child) => Transform.translate(
+              offset: Offset(0, _translateY.value),
+              child: Opacity(opacity: _opacity.value, child: child),
+            ),
+            child: QvButton(
+              buttonColor: ButtonColor.fireRed,
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+              child: Text(
+                '- ${widget.amount} HP',
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/services/enemy_attack_scheduling_service_test.dart
+++ b/test/services/enemy_attack_scheduling_service_test.dart
@@ -1,0 +1,181 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:questvale/data/models/enemy.dart';
+import 'package:questvale/data/models/scheduled_timer.dart';
+import 'package:questvale/data/providers/game_data_models/enemy_attack_data.dart';
+import 'package:questvale/helpers/shared_enums.dart';
+import 'package:questvale/services/enemy_attack_scheduling_service.dart';
+
+// Returns fixed values instead of real randomness, so weighted-selection
+// tests are deterministic rather than statistical.
+class _FixedRandom implements Random {
+  final double fixedDouble;
+  final int fixedInt;
+  _FixedRandom({this.fixedDouble = 0, this.fixedInt = 0});
+
+  @override
+  double nextDouble() => fixedDouble;
+
+  @override
+  int nextInt(int max) => fixedInt;
+
+  @override
+  bool nextBool() => false;
+}
+
+EnemyAttackData _attack(String name, {double weight = 1.0, int damage = 3}) {
+  return EnemyAttackData(
+    name: name,
+    damage: damage,
+    damageType: DamageType.physical,
+    cooldown: 8.0, // hours
+    weight: weight,
+  );
+}
+
+Enemy _enemy({String id = 'enemy-1'}) => Enemy(
+      id: id,
+      enemyDataId: 'field_rat',
+      encounterId: 'encounter-1',
+      currentHealth: 20,
+      position: 0,
+    );
+
+void main() {
+  group('selectMove', () {
+    test('picks the first attack when the roll lands within its weight', () {
+      final attacks = [_attack('Bite', weight: 1), _attack('Claw', weight: 3)];
+      final move = EnemyAttackSchedulingService.selectMove(
+          attacks, _FixedRandom(fixedDouble: 0.0));
+      expect(move.name, 'Bite');
+    });
+
+    test('picks a later attack once the roll exceeds earlier weights', () {
+      final attacks = [_attack('Bite', weight: 1), _attack('Claw', weight: 3)];
+      // roll = 0.5 * totalWeight(4) = 2.0 — exceeds Bite's weight (1),
+      // lands inside Claw's share.
+      final move = EnemyAttackSchedulingService.selectMove(
+          attacks, _FixedRandom(fixedDouble: 0.5));
+      expect(move.name, 'Claw');
+    });
+
+    test('falls back to a uniform pick when every weight is zero', () {
+      final attacks = [_attack('Bite', weight: 0), _attack('Claw', weight: 0)];
+      final move = EnemyAttackSchedulingService.selectMove(
+          attacks, _FixedRandom(fixedInt: 1));
+      expect(move.name, 'Claw');
+    });
+  });
+
+  group('buildInitialTimer', () {
+    test('converts the move\'s cooldown (hours) into remainingWork/nextTriggerAt', () {
+      final now = DateTime(2026, 1, 1, 12);
+      final move = _attack('Bite', damage: 4);
+      final timer = EnemyAttackSchedulingService.buildInitialTimer(
+        enemy: _enemy(),
+        encounterId: 'encounter-1',
+        move: move,
+        now: now,
+        id: 'timer-1',
+      );
+
+      expect(timer.ownerId, 'enemy-1');
+      expect(timer.encounterId, 'encounter-1');
+      expect(timer.kind, ScheduledTimerKind.enemyMove);
+      expect(timer.payload, 'Bite');
+      expect(timer.currentRate, 1.0);
+      expect(timer.remainingWorkMs, 8 * Duration.millisecondsPerHour);
+      expect(timer.nextTriggerAt, now.add(const Duration(hours: 8)));
+    });
+  });
+
+  group('recomputeSegment', () {
+    // Mirrors the ticket's worked trace exactly: an 8h Bite timer, a Slow
+    // (0.5x) applied 3h in, then Slow expiring 2h later.
+    test('closes and reopens segments under an arbitrary rate, matching the worked trace', () {
+      final spawn = DateTime(2026, 1, 1, 0);
+      final initial = ScheduledTimer(
+        id: 't1',
+        ownerId: 'enemy-1',
+        encounterId: 'encounter-1',
+        kind: ScheduledTimerKind.enemyMove,
+        payload: 'Bite',
+        remainingWorkMs: 8 * Duration.millisecondsPerHour,
+        segmentStartedAt: spawn,
+        currentRate: 1.0,
+        nextTriggerAt: spawn.add(const Duration(hours: 8)),
+      );
+
+      // T+3h: Slow starts (0.5x).
+      final slowed = EnemyAttackSchedulingService.recomputeSegment(
+        timer: initial,
+        newRate: 0.5,
+        at: spawn.add(const Duration(hours: 3)),
+      );
+      expect(slowed.remainingWorkMs, 5 * Duration.millisecondsPerHour);
+      expect(slowed.nextTriggerAt, spawn.add(const Duration(hours: 13)));
+
+      // T+5h: Slow expires, back to 1.0x.
+      final unslowed = EnemyAttackSchedulingService.recomputeSegment(
+        timer: slowed,
+        newRate: 1.0,
+        at: spawn.add(const Duration(hours: 5)),
+      );
+      expect(unslowed.remainingWorkMs, 4 * Duration.millisecondsPerHour);
+      expect(unslowed.nextTriggerAt, spawn.add(const Duration(hours: 9)));
+    });
+
+    test('a rate of 0 (Freeze) halts the timer instead of dividing by zero', () {
+      final spawn = DateTime(2026, 1, 1, 0);
+      final initial = ScheduledTimer(
+        id: 't1',
+        ownerId: 'enemy-1',
+        encounterId: 'encounter-1',
+        kind: ScheduledTimerKind.enemyMove,
+        payload: 'Bite',
+        remainingWorkMs: 8 * Duration.millisecondsPerHour,
+        segmentStartedAt: spawn,
+        nextTriggerAt: spawn.add(const Duration(hours: 8)),
+      );
+
+      final frozen = EnemyAttackSchedulingService.recomputeSegment(
+        timer: initial,
+        newRate: 0,
+        at: spawn.add(const Duration(hours: 1)),
+      );
+      expect(frozen.currentRate, 0);
+      expect(frozen.nextTriggerAt.isAfter(spawn.add(const Duration(days: 300))), isTrue);
+    });
+  });
+
+  group('nextDueTimer', () {
+    ScheduledTimer timerAt(String id, DateTime at) => ScheduledTimer(
+          id: id,
+          ownerId: id,
+          encounterId: 'encounter-1',
+          kind: ScheduledTimerKind.enemyMove,
+          payload: 'Bite',
+          remainingWorkMs: 0,
+          segmentStartedAt: at,
+          nextTriggerAt: at,
+        );
+
+    test('returns null when nothing is overdue', () {
+      final now = DateTime(2026, 1, 1);
+      final timers = [timerAt('a', now.add(const Duration(hours: 1)))];
+      expect(EnemyAttackSchedulingService.nextDueTimer(timers, now), isNull);
+    });
+
+    test('replays multiple overdue timers oldest-first, not by list order', () {
+      final now = DateTime(2026, 1, 2);
+      final newer = timerAt('newer', now.subtract(const Duration(hours: 1)));
+      final older = timerAt('older', now.subtract(const Duration(hours: 5)));
+      final future = timerAt('future', now.add(const Duration(hours: 1)));
+      final timers = [newer, future, older];
+
+      final due = EnemyAttackSchedulingService.nextDueTimer(timers, now);
+      expect(due?.id, 'older');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the Enemy Attack Scheduling ticket (closes #27): a time-based scheduling engine for enemy attacks, wired into both combat views, plus the reconciliation/notification/UX refinements that came out of testing it live.

- **Core engine** (`EnemyAttackSchedulingService`, `ScheduledTimer` model/table): spawn-time move selection, chronological reconciliation/replay of overdue attacks, move execution and re-arming, with a generic rate-modifier hook point for future Slow/Freeze support.
- **Capped reconciliation**: an enemy resolves at most one attack per reconcile() call no matter how long the app was closed — re-arming chains from `now`, not the missed deadline, so a missed day costs one hit instead of compounding every elapsed cooldown cycle. Also guarantees at most one `ScheduledTimer` (and one notification) pending per enemy at a time.
- **Attack-incoming notifications**: local notifications via the existing `flutter_local_notifications` setup, scheduled/cancelled from the same choke point that arms each timer so the two lifecycles always match.
- **Live countdowns in both combat views**: the todo tab's combat status card and the World tab's enemy inspect panel both show real attack names/countdowns (replacing random placeholders), self-refresh every second, and auto-resolve an expired timer instead of freezing at `00:00`.
- **Damage-taken toast**: a "- N HP" pill (mirroring the existing AP toast) fires whenever a reconciled enemy attack actually damages the player, in whichever view the player is in.

## Test plan
- [x] `flutter analyze` / `flutter test` clean throughout
- [x] Unit tests for the pure scheduling math (weighted move selection, segment recompute under an arbitrary rate, chronological replay ordering) — reproduces the architecture note's worked trace number-for-number
- [x] Manual iOS simulator verification at each stage: DB-level timer/HP checks, capped-reconciliation behavior, countdown auto-reload with zero taps, 1s tick cadence, and the damage toast (confirmed via a temporary debug print matched against the exact HP delta, since the toast's animation is too short to reliably screenshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)